### PR TITLE
Support structured recipe ingredient_groups schema

### DIFF
--- a/garden.config.ts
+++ b/garden.config.ts
@@ -273,6 +273,14 @@ const config: Configuration = {
           transformers: digitalGardenTransformers,
         },
         {
+          id: "ingredients" as const,
+          basePath: "ingredients",
+          pattern: "*.{md,mdx}",
+          destinationPath: "ingredients",
+          transformers: digitalGardenTransformers,
+          // No `search` block: ingredients are a glossary for derivation, not pages.
+        },
+        {
           id: "recipes" as const,
           basePath: "recipes",
           pattern: "*.{md,mdx}",

--- a/src/components/content/ContentDetail.astro
+++ b/src/components/content/ContentDetail.astro
@@ -27,6 +27,7 @@ const { Content } = await render(entry);
   </slot>
 
   <Prose>
+    <slot name="pre-content" />
     <Content components={getMdxComponents()} />
   </Prose>
 </SidebarLayout>

--- a/src/components/content/ContentSidebar.astro
+++ b/src/components/content/ContentSidebar.astro
@@ -11,11 +11,19 @@ export interface Props {
 const { entry } = Astro.props;
 const { headings } = await render(entry);
 const { outboundLinks, inboundLinks } = getEntryIndexRecord(entry.id);
+
+// Recipes render their ingredient list via a component rather than in the MDX
+// body, so the "Ingredients" heading is absent from `headings`. Re-add it (first,
+// matching the on-page order) so the table of contents stays the same as before.
+const tocHeadings =
+  entry.collection === "recipes" && entry.data.ingredient_groups.length > 0
+    ? [{ depth: 2, text: "Ingredients", slug: "ingredients" }, ...headings]
+    : headings;
 ---
 
 <div class="space-y-4">
   <slot />
 
-  <Toc headings={headings} title={entry.data.title} />
+  <Toc headings={tocHeadings} title={entry.data.title} />
   <ContentLinks outboundLinks={outboundLinks} inboundLinks={inboundLinks} />
 </div>

--- a/src/components/content/recipes/IngredientList.astro
+++ b/src/components/content/recipes/IngredientList.astro
@@ -1,0 +1,85 @@
+---
+import type { CollectionEntry } from "astro:content";
+import Link from "@components/ui/Link.astro";
+import { getIngredientNameMap, prettifyId, formatIngredientLine } from "src/lib/recipes/ingredients";
+import { buildContentEntryUrl } from "src/lib/zendo/plugins/remarkWikiLink.mjs";
+import entryIndex from "src/data/index.json";
+
+export interface Props {
+  recipe: CollectionEntry<"recipes">;
+}
+
+type IngredientItem = Props["recipe"]["data"]["ingredient_groups"][number]["ingredients"][number];
+type Segment = { text: string } | { href: string; label: string };
+
+const { recipe } = Astro.props;
+const groups = recipe.data.ingredient_groups;
+
+const nameMap = await getIngredientNameMap();
+
+function lineFor(item: IngredientItem): string {
+  if (item.id) {
+    const name = nameMap.get(item.id) ?? prettifyId(item.id);
+    return formatIngredientLine(item, name);
+  }
+
+  // Note-only entry (e.g. a cross-reference to another recipe's ingredients).
+  return item.note ?? "";
+}
+
+// Resolves wikilinks (`[[slug|label]]`) to internal links the same way the MDX
+// pipeline does, so ingredient cross-references render identically.
+function toSegments(text: string): Segment[] {
+  const segments: Segment[] = [];
+  const regex = /(?<!!)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(regex)) {
+    const start = match.index!;
+    if (start > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, start) });
+    }
+
+    const destination = (match[1] ?? "").trim();
+    const label = (match[2] ?? match[1] ?? "").trim();
+    const record = entryIndex.find((entry) => entry.ids.some((id) => id.toLowerCase() === destination.toLowerCase()));
+
+    if (record) {
+      segments.push({ href: buildContentEntryUrl(record), label });
+    } else {
+      segments.push({ text: label });
+    }
+
+    lastIndex = start + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+---
+
+{
+  groups.length > 0 && (
+    <>
+      <h2 id="ingredients">Ingredients</h2>
+
+      {groups.map((group) => (
+        <>
+          {group.group && <p>For the {group.group.toLowerCase()}:</p>}
+          <ul>
+            {group.ingredients.map((item) => (
+              <li>
+                {toSegments(lineFor(item)).map((segment) =>
+                  "href" in segment ? <Link href={segment.href}>{segment.label}</Link> : segment.text
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      ))}
+    </>
+  )
+}

--- a/src/components/content/recipes/RecipeMeta.astro
+++ b/src/components/content/recipes/RecipeMeta.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import RelativeDate from "@components/ui/RelativeDate.astro";
+import { getRecipeDiets, type Diet } from "src/lib/recipes/diets";
 import types from "./types.json";
 import cuisines from "./cuisines.json";
 import diets from "./diets.json";
@@ -12,9 +13,11 @@ export interface Props {
 
 const { content, compact = false } = Astro.props;
 
+const recipeDiets = await getRecipeDiets(content);
+
 type recipeType = CollectionEntry<"recipes">["data"]["type"];
 type RecipeCuisine = CollectionEntry<"recipes">["data"]["cuisine"];
-type RecipeDiet = CollectionEntry<"recipes">["data"]["diets"][number];
+type RecipeDiet = Diet;
 
 const TYPE_MAP = types satisfies Record<recipeType, { emoji: string; label: string }>;
 const CUISINE_MAP = cuisines satisfies Record<RecipeCuisine, { emoji: string; label: string }>;
@@ -63,10 +66,10 @@ function getDietDisplay(diet: RecipeDiet): string {
   }
 
   {
-    !compact && content.data.diets && content.data.diets.length > 0 && (
+    !compact && recipeDiets.length > 0 && (
       <>
         <span class="mx-0.5">•</span>
-        <span>{content.data.diets.map((diet) => getDietDisplay(diet)).join(", ")}</span>
+        <span>{recipeDiets.map((diet) => getDietDisplay(diet)).join(", ")}</span>
       </>
     )
   }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -91,6 +91,18 @@ export const collections = {
     loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/nows" }),
   }),
 
+  ingredients: defineCollection({
+    schema: obsidianSchema.extend(
+      z.object({
+        aliases: z.array(z.string()).optional(),
+        category: z.string().optional(),
+        allergens: z.array(z.string()).optional().default([]),
+        diets: z.array(z.enum(["omnivore", "vegetarian", "vegan", "pescatarian"])),
+      }).shape
+    ),
+    loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/ingredients" }),
+  }),
+
   recipes: defineCollection({
     schema: obsidianSchema.extend(
       z.object({
@@ -105,9 +117,39 @@ export const collections = {
           "greek",
           "british",
         ]),
-        diets: z.array(z.enum(["omnivore", "vegetarian", "vegan", "pescatarian"])),
         type: z.enum(["starter", "first-course", "main-course", "single-dish", "sauce", "side", "dessert", "other"]),
         serves: z.preprocess((val) => (val === null ? undefined : val), z.number().optional()),
+        ingredient_groups: z
+          .array(
+            z.object({
+              group: z.string().optional(),
+              ingredients: z.array(
+                z.preprocess(
+                  // Some recipes reference another recipe's ingredients via a
+                  // note-only line that the vault serializes as a bare string,
+                  // e.g. "note: 'Ingredients for [[bbq-sauce|BBQ Sauce]]'".
+                  (val) => {
+                    if (typeof val === "string") {
+                      const note = val
+                        .replace(/^note:\s*/, "")
+                        .replace(/^'([\s\S]*)'$/, "$1")
+                        .replace(/^"([\s\S]*)"$/, "$1");
+                      return { note };
+                    }
+                    return val;
+                  },
+                  z.object({
+                    id: z.string().optional(),
+                    quantity: z.number().optional(),
+                    unit: z.string().optional(),
+                    note: z.string().optional(),
+                  })
+                )
+              ),
+            })
+          )
+          .optional()
+          .default([]),
       }).shape
     ),
     loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/recipes" }),

--- a/src/content/ingredients/00-flour.mdx
+++ b/src/content/ingredients/00-flour.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - 00 Flour
+  - 00-flour
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: 00 Flour
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# 00 Flour

--- a/src/content/ingredients/all-purpose-flour.mdx
+++ b/src/content/ingredients/all-purpose-flour.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - All-Purpose Flour
+  - all-purpose-flour
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: All-Purpose Flour
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# All-Purpose Flour

--- a/src/content/ingredients/anchovy-fillets.mdx
+++ b/src/content/ingredients/anchovy-fillets.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Anchovy Fillets
+  - anchovy-fillets
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Anchovy Fillets
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Anchovy Fillets

--- a/src/content/ingredients/apple-cider-vinegar.mdx
+++ b/src/content/ingredients/apple-cider-vinegar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Apple Cider Vinegar
+  - apple-cider-vinegar
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Apple Cider Vinegar
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Apple Cider Vinegar

--- a/src/content/ingredients/avocado.mdx
+++ b/src/content/ingredients/avocado.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Avocado
+  - avocado
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Avocado
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Avocado

--- a/src/content/ingredients/baking-powder.mdx
+++ b/src/content/ingredients/baking-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Baking Powder
+  - baking-powder
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Baking Powder
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Baking Powder

--- a/src/content/ingredients/balsamic-glaze.mdx
+++ b/src/content/ingredients/balsamic-glaze.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Balsamic Glaze
+  - balsamic-glaze
+allergens:
+  - sulphites
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Balsamic Glaze
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Balsamic Glaze

--- a/src/content/ingredients/banana-whey-protein.mdx
+++ b/src/content/ingredients/banana-whey-protein.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Banana Whey Protein
+  - banana-whey-protein
+allergens:
+  - dairy
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Banana Whey Protein
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Banana Whey Protein

--- a/src/content/ingredients/banana.mdx
+++ b/src/content/ingredients/banana.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ripe Banana Flesh
+  - banana
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ripe Banana Flesh
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Ripe Banana Flesh

--- a/src/content/ingredients/barbecue-sauce.mdx
+++ b/src/content/ingredients/barbecue-sauce.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Barbecue Sauce
+  - barbecue-sauce
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Barbecue Sauce
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Barbecue Sauce

--- a/src/content/ingredients/basmati-rice.mdx
+++ b/src/content/ingredients/basmati-rice.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Basmati Rice
+  - basmati-rice
+allergens: []
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Basmati Rice
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Basmati Rice

--- a/src/content/ingredients/bay-leaves.mdx
+++ b/src/content/ingredients/bay-leaves.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Bay Leaves
+  - bay-leaves
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Bay Leaves
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Bay Leaves

--- a/src/content/ingredients/beef-chuck.mdx
+++ b/src/content/ingredients/beef-chuck.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Beef Chunks
+  - beef-chuck
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Beef Chunks
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Beef Chunks

--- a/src/content/ingredients/beef-short-rib.mdx
+++ b/src/content/ingredients/beef-short-rib.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Beef Short Rib
+  - beef-short-rib
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Beef Short Rib
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Beef Short Rib

--- a/src/content/ingredients/beef-stock.mdx
+++ b/src/content/ingredients/beef-stock.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Beef Stock
+  - beef-stock
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Beef Stock
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Beef Stock

--- a/src/content/ingredients/beef-tenderloin.mdx
+++ b/src/content/ingredients/beef-tenderloin.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Beef Tenderloin Steaks
+  - beef-tenderloin
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Beef Tenderloin Steaks
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Beef Tenderloin Steaks

--- a/src/content/ingredients/beef-topside.mdx
+++ b/src/content/ingredients/beef-topside.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Beef Topside
+  - beef-topside
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Beef Topside
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Beef Topside

--- a/src/content/ingredients/black-beans.mdx
+++ b/src/content/ingredients/black-beans.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Black Beans
+  - black-beans
+allergens: []
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Black Beans
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Black Beans

--- a/src/content/ingredients/black-peppercorns.mdx
+++ b/src/content/ingredients/black-peppercorns.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Black Peppercorns
+  - black-peppercorns
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Black Peppercorns
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Black Peppercorns

--- a/src/content/ingredients/blackberries.mdx
+++ b/src/content/ingredients/blackberries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Blackberries
+  - blackberries
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Blackberries
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Blackberries

--- a/src/content/ingredients/blueberries.mdx
+++ b/src/content/ingredients/blueberries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Blueberries
+  - blueberries
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Blueberries
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Blueberries

--- a/src/content/ingredients/brandy.mdx
+++ b/src/content/ingredients/brandy.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Brandy
+  - brandy
+allergens:
+  - sulphites
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Brandy
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Brandy

--- a/src/content/ingredients/breadcrumbs.mdx
+++ b/src/content/ingredients/breadcrumbs.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Breadcrumbs
+  - breadcrumbs
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Breadcrumbs
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Breadcrumbs

--- a/src/content/ingredients/brie.mdx
+++ b/src/content/ingredients/brie.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Brie
+  - brie
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Brie
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Brie

--- a/src/content/ingredients/brown-sugar.mdx
+++ b/src/content/ingredients/brown-sugar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Brown Sugar
+  - brown-sugar
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Brown Sugar
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Brown Sugar

--- a/src/content/ingredients/burrata.mdx
+++ b/src/content/ingredients/burrata.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Burrata
+  - burrata
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Burrata
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Burrata

--- a/src/content/ingredients/butter.mdx
+++ b/src/content/ingredients/butter.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Butter
+  - butter
+allergens:
+  - dairy
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Butter
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Butter

--- a/src/content/ingredients/canned-tuna-in-oil.mdx
+++ b/src/content/ingredients/canned-tuna-in-oil.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Canned Tuna in Oil
+  - canned-tuna-in-oil
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Canned Tuna in Oil
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Canned Tuna in Oil

--- a/src/content/ingredients/caper-berries.mdx
+++ b/src/content/ingredients/caper-berries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Caper Berries
+  - caper-berries
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Caper Berries
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Caper Berries

--- a/src/content/ingredients/capers.mdx
+++ b/src/content/ingredients/capers.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Capers
+  - capers
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Capers
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Capers

--- a/src/content/ingredients/carnaroli-rice.mdx
+++ b/src/content/ingredients/carnaroli-rice.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Carnaroli Rice
+  - carnaroli-rice
+allergens: []
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Carnaroli Rice
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Carnaroli Rice

--- a/src/content/ingredients/carrot.mdx
+++ b/src/content/ingredients/carrot.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Carrot
+  - carrot
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Carrot
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Carrot

--- a/src/content/ingredients/cashews.mdx
+++ b/src/content/ingredients/cashews.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Cashews
+  - cashews
+allergens:
+  - nuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cashews
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cashews

--- a/src/content/ingredients/cauliflower.mdx
+++ b/src/content/ingredients/cauliflower.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Medium Cauliflower
+  - cauliflower
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Medium Cauliflower
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Medium Cauliflower

--- a/src/content/ingredients/cayenne-pepper.mdx
+++ b/src/content/ingredients/cayenne-pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cayenne Pepper
+  - cayenne-pepper
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cayenne Pepper
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cayenne Pepper

--- a/src/content/ingredients/celery-stalk.mdx
+++ b/src/content/ingredients/celery-stalk.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Celery Stalk
+  - celery-stalk
+allergens:
+  - celery
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Celery Stalk
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Celery Stalk

--- a/src/content/ingredients/champignon-mushrooms.mdx
+++ b/src/content/ingredients/champignon-mushrooms.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Champignon Mushrooms
+  - champignon-mushrooms
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Champignon Mushrooms
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Champignon Mushrooms

--- a/src/content/ingredients/cheddar.mdx
+++ b/src/content/ingredients/cheddar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cheddar
+  - cheddar
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Cheddar
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cheddar

--- a/src/content/ingredients/cherry-tomato.mdx
+++ b/src/content/ingredients/cherry-tomato.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cherry Tomato
+  - cherry-tomato
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cherry Tomato
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cherry Tomato

--- a/src/content/ingredients/chicken-breast.mdx
+++ b/src/content/ingredients/chicken-breast.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Chicken Breast
+  - chicken-breast
+allergens: []
+category: poultry
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Chicken Breast
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chicken Breast

--- a/src/content/ingredients/chicken-thighs.mdx
+++ b/src/content/ingredients/chicken-thighs.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Chicken Thighs
+  - chicken-thighs
+allergens: []
+category: poultry
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Chicken Thighs
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chicken Thighs

--- a/src/content/ingredients/chicken-wings.mdx
+++ b/src/content/ingredients/chicken-wings.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Chicken Wings
+  - chicken-wings
+allergens: []
+category: poultry
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Chicken Wings
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chicken Wings

--- a/src/content/ingredients/chicken.mdx
+++ b/src/content/ingredients/chicken.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Chicken
+  - chicken
+allergens: []
+category: poultry
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Chicken
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chicken

--- a/src/content/ingredients/chickpeas.mdx
+++ b/src/content/ingredients/chickpeas.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Canned Chickpeas
+  - chickpeas
+allergens: []
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Canned Chickpeas
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Canned Chickpeas

--- a/src/content/ingredients/chili-flakes.mdx
+++ b/src/content/ingredients/chili-flakes.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Chili Flakes
+  - chili-flakes
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Chili Flakes
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chili Flakes

--- a/src/content/ingredients/chilli-powder.mdx
+++ b/src/content/ingredients/chilli-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Chilli Powder
+  - chilli-powder
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Chilli Powder
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chilli Powder

--- a/src/content/ingredients/chives.mdx
+++ b/src/content/ingredients/chives.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Chives
+  - chives
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Chives
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chives

--- a/src/content/ingredients/chocolate-chips.mdx
+++ b/src/content/ingredients/chocolate-chips.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Chocolate Chips
+  - chocolate-chips
+allergens:
+  - nuts
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Chocolate Chips
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Chocolate Chips

--- a/src/content/ingredients/clarified-butter.mdx
+++ b/src/content/ingredients/clarified-butter.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Clarified Butter
+  - clarified-butter
+allergens:
+  - dairy
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Clarified Butter
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Clarified Butter

--- a/src/content/ingredients/cloves.mdx
+++ b/src/content/ingredients/cloves.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cloves
+  - cloves
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cloves
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cloves

--- a/src/content/ingredients/cocoa-powder.mdx
+++ b/src/content/ingredients/cocoa-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Unsweetened Cocoa Powder
+  - cocoa-powder
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Unsweetened Cocoa Powder
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Unsweetened Cocoa Powder

--- a/src/content/ingredients/coconut-milk.mdx
+++ b/src/content/ingredients/coconut-milk.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Coconut Milk
+  - coconut-milk
+allergens: []
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Coconut Milk
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Coconut Milk

--- a/src/content/ingredients/cooked-ham.mdx
+++ b/src/content/ingredients/cooked-ham.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Cooked Ham
+  - cooked-ham
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Cooked Ham
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cooked Ham

--- a/src/content/ingredients/corn.mdx
+++ b/src/content/ingredients/corn.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Corn
+  - corn
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Corn
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Corn

--- a/src/content/ingredients/cornstarch.mdx
+++ b/src/content/ingredients/cornstarch.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cornflour
+  - cornstarch
+allergens: []
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cornflour
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cornflour

--- a/src/content/ingredients/cow-ricotta.mdx
+++ b/src/content/ingredients/cow-ricotta.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cow Ricotta
+  - cow-ricotta
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Cow Ricotta
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cow Ricotta

--- a/src/content/ingredients/cream-cheese.mdx
+++ b/src/content/ingredients/cream-cheese.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cream Cheese
+  - cream-cheese
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Cream Cheese
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cream Cheese

--- a/src/content/ingredients/cucumber.mdx
+++ b/src/content/ingredients/cucumber.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cucumber
+  - cucumber
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cucumber
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Cucumber

--- a/src/content/ingredients/dark-chocolate.mdx
+++ b/src/content/ingredients/dark-chocolate.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Dark Chocolate
+  - dark-chocolate
+allergens:
+  - nuts
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dark Chocolate
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dark Chocolate

--- a/src/content/ingredients/dashi-powder.mdx
+++ b/src/content/ingredients/dashi-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Dashi Powder
+  - dashi-powder
+allergens:
+  - fish
+  - shellfish
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Dashi Powder
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dashi Powder

--- a/src/content/ingredients/delica-pumpkin.mdx
+++ b/src/content/ingredients/delica-pumpkin.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Delica Pumpkin
+  - delica-pumpkin
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Delica Pumpkin
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Delica Pumpkin

--- a/src/content/ingredients/digestive-biscuits.mdx
+++ b/src/content/ingredients/digestive-biscuits.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Digestive Biscuits
+  - digestive-biscuits
+allergens:
+  - dairy
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Digestive Biscuits
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Digestive Biscuits

--- a/src/content/ingredients/dijon-mustard.mdx
+++ b/src/content/ingredients/dijon-mustard.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Dijon Mustard
+  - dijon-mustard
+allergens:
+  - mustard
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dijon Mustard
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dijon Mustard

--- a/src/content/ingredients/dried-chili-pepper.mdx
+++ b/src/content/ingredients/dried-chili-pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Dried Chili Pepper
+  - dried-chili-pepper
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dried Chili Pepper
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dried Chili Pepper

--- a/src/content/ingredients/dried-rice-vermicelli.mdx
+++ b/src/content/ingredients/dried-rice-vermicelli.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Dried Rice Vermicelli
+  - dried-rice-vermicelli
+allergens: []
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dried Rice Vermicelli
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dried Rice Vermicelli

--- a/src/content/ingredients/dried-wakame.mdx
+++ b/src/content/ingredients/dried-wakame.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Dried Wakame
+  - dried-wakame
+allergens:
+  - shellfish
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dried Wakame
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dried Wakame

--- a/src/content/ingredients/dry-white-wine.mdx
+++ b/src/content/ingredients/dry-white-wine.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Dry White Wine
+  - dry-white-wine
+allergens:
+  - sulphites
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Dry White Wine
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Dry White Wine

--- a/src/content/ingredients/durum-wheat-semolina.mdx
+++ b/src/content/ingredients/durum-wheat-semolina.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Remilled Durum Wheat Semolina
+  - durum-wheat-semolina
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Remilled Durum Wheat Semolina
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Remilled Durum Wheat Semolina

--- a/src/content/ingredients/egg-yolk.mdx
+++ b/src/content/ingredients/egg-yolk.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Egg Yolk
+  - egg-yolk
+allergens:
+  - egg
+category: egg
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Egg Yolk
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Egg Yolk

--- a/src/content/ingredients/egg.mdx
+++ b/src/content/ingredients/egg.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Eggs
+  - egg
+allergens:
+  - egg
+category: egg
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Eggs
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Eggs

--- a/src/content/ingredients/eggplant.mdx
+++ b/src/content/ingredients/eggplant.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Eggplant
+  - eggplant
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Eggplant
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Eggplant

--- a/src/content/ingredients/extra-virgin-olive-oil.mdx
+++ b/src/content/ingredients/extra-virgin-olive-oil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Extra Virgin Olive Oil
+  - extra-virgin-olive-oil
+allergens: []
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Extra Virgin Olive Oil
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Extra Virgin Olive Oil

--- a/src/content/ingredients/fine-salt.mdx
+++ b/src/content/ingredients/fine-salt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fine Salt
+  - fine-salt
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fine Salt
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fine Salt

--- a/src/content/ingredients/fior-di-latte-mozzarella.mdx
+++ b/src/content/ingredients/fior-di-latte-mozzarella.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fior di Latte Mozzarella
+  - fior-di-latte-mozzarella
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Fior di Latte Mozzarella
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fior di Latte Mozzarella

--- a/src/content/ingredients/firm-tofu.mdx
+++ b/src/content/ingredients/firm-tofu.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Firm Tofu
+  - firm-tofu
+allergens:
+  - soy
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Firm Tofu
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Firm Tofu

--- a/src/content/ingredients/fresh-bakers-yeast.mdx
+++ b/src/content/ingredients/fresh-bakers-yeast.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Fresh Baker’s Yeast
+  - Fresh Baker's Yeast
+  - fresh-bakers-yeast
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Baker’s Yeast
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Baker’s Yeast

--- a/src/content/ingredients/fresh-basil.mdx
+++ b/src/content/ingredients/fresh-basil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Basil Leaves
+  - fresh-basil
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Basil Leaves
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Basil Leaves

--- a/src/content/ingredients/fresh-chili.mdx
+++ b/src/content/ingredients/fresh-chili.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Chili
+  - fresh-chili
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Chili
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Chili

--- a/src/content/ingredients/fresh-cilantro.mdx
+++ b/src/content/ingredients/fresh-cilantro.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Fresh Cilantro
+  - fresh-coriander
+  - fresh-cilantro
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Cilantro
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Cilantro

--- a/src/content/ingredients/fresh-coriander.mdx
+++ b/src/content/ingredients/fresh-coriander.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Cilantro
+  - fresh-coriander
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Cilantro
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Cilantro

--- a/src/content/ingredients/fresh-ginger.mdx
+++ b/src/content/ingredients/fresh-ginger.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Ginger
+  - fresh-ginger
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Ginger
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Ginger

--- a/src/content/ingredients/fresh-liquid-cream.mdx
+++ b/src/content/ingredients/fresh-liquid-cream.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Liquid Cream
+  - fresh-liquid-cream
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Fresh Liquid Cream
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Liquid Cream

--- a/src/content/ingredients/fresh-mint.mdx
+++ b/src/content/ingredients/fresh-mint.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Mint
+  - fresh-mint
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Mint
+updatedAt: 2026-06-01T08:51:48.000Z
+contentType: ingredients
+---
+# Fresh Mint

--- a/src/content/ingredients/fresh-tuna-fillet.mdx
+++ b/src/content/ingredients/fresh-tuna-fillet.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Fresh Tuna Fillet
+  - fresh-tuna-fillet
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Fresh Tuna Fillet
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Fresh Tuna Fillet

--- a/src/content/ingredients/gaeta-olives.mdx
+++ b/src/content/ingredients/gaeta-olives.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Gaeta Olives
+  - gaeta-olives
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Gaeta Olives
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Gaeta Olives

--- a/src/content/ingredients/garlic-ginger-paste.mdx
+++ b/src/content/ingredients/garlic-ginger-paste.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Garlic or Ginger Paste
+  - garlic-ginger-paste
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Garlic or Ginger Paste
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Garlic or Ginger Paste

--- a/src/content/ingredients/garlic-powder.mdx
+++ b/src/content/ingredients/garlic-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Garlic Powder
+  - garlic-powder
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Garlic Powder
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Garlic Powder

--- a/src/content/ingredients/garlic.mdx
+++ b/src/content/ingredients/garlic.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Garlic Clove
+  - garlic
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Garlic Clove
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Garlic Clove

--- a/src/content/ingredients/genovese-pesto.mdx
+++ b/src/content/ingredients/genovese-pesto.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Genovese Pesto
+  - genovese-pesto
+allergens:
+  - dairy
+  - nuts
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Genovese Pesto
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Genovese Pesto

--- a/src/content/ingredients/gilthead-bream-fillet.mdx
+++ b/src/content/ingredients/gilthead-bream-fillet.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Gilthead Bream Fillet
+  - gilthead-bream-fillet
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Gilthead Bream Fillet
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Gilthead Bream Fillet

--- a/src/content/ingredients/golden-apple.mdx
+++ b/src/content/ingredients/golden-apple.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Golden Apples
+  - golden-apple
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Golden Apples
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Golden Apples

--- a/src/content/ingredients/golden-onion.mdx
+++ b/src/content/ingredients/golden-onion.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Golden Onion
+  - golden-onion
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Golden Onion
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Golden Onion

--- a/src/content/ingredients/gorgonzola.mdx
+++ b/src/content/ingredients/gorgonzola.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Gorgonzola
+  - gorgonzola
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Gorgonzola
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Gorgonzola

--- a/src/content/ingredients/grana-padano.mdx
+++ b/src/content/ingredients/grana-padano.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Grana Padano DOP
+  - grana-padano
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Grana Padano DOP
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Grana Padano DOP

--- a/src/content/ingredients/granulated-sugar.mdx
+++ b/src/content/ingredients/granulated-sugar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Granulated Sugar
+  - granulated-sugar
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Granulated Sugar
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Granulated Sugar

--- a/src/content/ingredients/greek-yogurt.mdx
+++ b/src/content/ingredients/greek-yogurt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Greek Yogurt
+  - greek-yogurt
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Greek Yogurt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Greek Yogurt

--- a/src/content/ingredients/green-olives.mdx
+++ b/src/content/ingredients/green-olives.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Green Olives
+  - green-olives
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Green Olives
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Green Olives

--- a/src/content/ingredients/green-peppercorns-brine.mdx
+++ b/src/content/ingredients/green-peppercorns-brine.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Green Peppercorns in Brine
+  - green-peppercorns-brine
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Green Peppercorns in Brine
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Green Peppercorns in Brine

--- a/src/content/ingredients/ground-beef.mdx
+++ b/src/content/ingredients/ground-beef.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Ground Beef
+  - ground-beef
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Ground Beef
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Beef

--- a/src/content/ingredients/ground-cinnamon.mdx
+++ b/src/content/ingredients/ground-cinnamon.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ground Cinnamon
+  - ground-cinnamon
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ground Cinnamon
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Cinnamon

--- a/src/content/ingredients/ground-coriander.mdx
+++ b/src/content/ingredients/ground-coriander.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ground Coriander
+  - ground-coriander
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ground Coriander
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Coriander

--- a/src/content/ingredients/ground-cumin.mdx
+++ b/src/content/ingredients/ground-cumin.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ground Cumin
+  - ground-cumin
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ground Cumin
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Cumin

--- a/src/content/ingredients/ground-garam-masala.mdx
+++ b/src/content/ingredients/ground-garam-masala.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ground Garam Masala
+  - ground-garam-masala
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ground Garam Masala
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Garam Masala

--- a/src/content/ingredients/ground-pork.mdx
+++ b/src/content/ingredients/ground-pork.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Ground Pork
+  - ground-pork
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Ground Pork
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Pork

--- a/src/content/ingredients/ground-turmeric.mdx
+++ b/src/content/ingredients/ground-turmeric.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ground Turmeric
+  - ground-turmeric
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ground Turmeric
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ground Turmeric

--- a/src/content/ingredients/guanciale.mdx
+++ b/src/content/ingredients/guanciale.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Guanciale
+  - guanciale
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Guanciale
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Guanciale

--- a/src/content/ingredients/hamburger-bun.mdx
+++ b/src/content/ingredients/hamburger-bun.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Hamburger Bun
+  - hamburger-bun
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Hamburger Bun
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Hamburger Bun

--- a/src/content/ingredients/hazelnuts.mdx
+++ b/src/content/ingredients/hazelnuts.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Hazelnuts
+  - hazelnuts
+allergens:
+  - nuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Hazelnuts
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Hazelnuts

--- a/src/content/ingredients/heavy-cream.mdx
+++ b/src/content/ingredients/heavy-cream.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Heavy Cream
+  - heavy-cream
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Fresh Heavy Cream
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Fresh Heavy Cream

--- a/src/content/ingredients/honey.mdx
+++ b/src/content/ingredients/honey.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Honey
+  - honey
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Honey
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Honey

--- a/src/content/ingredients/hot-paprika.mdx
+++ b/src/content/ingredients/hot-paprika.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Hot Paprika
+  - hot-paprika
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Hot Paprika
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Hot Paprika

--- a/src/content/ingredients/ice-cubes.mdx
+++ b/src/content/ingredients/ice-cubes.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ice Cubes
+  - ice-cubes
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ice Cubes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ice Cubes

--- a/src/content/ingredients/ketchup.mdx
+++ b/src/content/ingredients/ketchup.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ketchup
+  - ketchup
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ketchup
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ketchup

--- a/src/content/ingredients/king-prawns.mdx
+++ b/src/content/ingredients/king-prawns.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - King Prawns
+  - king-prawns
+allergens:
+  - shellfish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: King Prawns
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# King Prawns

--- a/src/content/ingredients/lambs-lettuce.mdx
+++ b/src/content/ingredients/lambs-lettuce.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Lamb’s Lettuce
+  - Lamb's Lettuce
+  - lambs-lettuce
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lamb’s Lettuce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lamb’s Lettuce

--- a/src/content/ingredients/lean-beef.mdx
+++ b/src/content/ingredients/lean-beef.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Lean Beef
+  - lean-beef
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Lean Beef
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lean Beef

--- a/src/content/ingredients/leek.mdx
+++ b/src/content/ingredients/leek.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Leek
+  - leek
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Leek
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Leek

--- a/src/content/ingredients/lemon-juice.mdx
+++ b/src/content/ingredients/lemon-juice.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lemon Juice
+  - lemon-juice
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lemon Juice
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lemon Juice

--- a/src/content/ingredients/lemon-thyme.mdx
+++ b/src/content/ingredients/lemon-thyme.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lemon Thyme
+  - lemon-thyme
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lemon Thyme
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lemon Thyme

--- a/src/content/ingredients/lemon-zest.mdx
+++ b/src/content/ingredients/lemon-zest.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lemon Zest
+  - lemon-zest
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lemon Zest
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lemon Zest

--- a/src/content/ingredients/lemon.mdx
+++ b/src/content/ingredients/lemon.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lemon
+  - lemon
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lemon
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lemon

--- a/src/content/ingredients/lentils.mdx
+++ b/src/content/ingredients/lentils.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Cooked Lentils
+  - lentils
+allergens: []
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Cooked Lentils
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Cooked Lentils

--- a/src/content/ingredients/lettuce.mdx
+++ b/src/content/ingredients/lettuce.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lettuce
+  - lettuce
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lettuce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lettuce

--- a/src/content/ingredients/light-soy-sauce.mdx
+++ b/src/content/ingredients/light-soy-sauce.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Light Soy Sauce
+  - light-soy-sauce
+allergens:
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Light Soy Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Light Soy Sauce

--- a/src/content/ingredients/lime-juice.mdx
+++ b/src/content/ingredients/lime-juice.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lime Juice
+  - lime-juice
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lime Juice
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lime Juice

--- a/src/content/ingredients/lime-zest.mdx
+++ b/src/content/ingredients/lime-zest.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Lime Zest
+  - lime-zest
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Lime Zest
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Lime Zest

--- a/src/content/ingredients/low-fat-yogurt.mdx
+++ b/src/content/ingredients/low-fat-yogurt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Low-Fat Yogurt
+  - low-fat-yogurt
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Low-Fat Yogurt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Low-Fat Yogurt

--- a/src/content/ingredients/maple-syrup.mdx
+++ b/src/content/ingredients/maple-syrup.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Maple Syrup
+  - maple-syrup
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Maple Syrup
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Maple Syrup

--- a/src/content/ingredients/mayonnaise.mdx
+++ b/src/content/ingredients/mayonnaise.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Mayonnaise
+  - mayonnaise
+allergens:
+  - egg
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Mayonnaise
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mayonnaise

--- a/src/content/ingredients/meat-broth.mdx
+++ b/src/content/ingredients/meat-broth.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Meat Broth
+  - meat-broth
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Meat Broth
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Meat Broth

--- a/src/content/ingredients/mild-curry-powder.mdx
+++ b/src/content/ingredients/mild-curry-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Mild Curry Powder
+  - mild-curry-powder
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Mild Curry Powder
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mild Curry Powder

--- a/src/content/ingredients/milk.mdx
+++ b/src/content/ingredients/milk.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Milk
+  - milk
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Milk
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Milk

--- a/src/content/ingredients/mirin.mdx
+++ b/src/content/ingredients/mirin.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Mirin
+  - mirin
+allergens:
+  - gluten
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Mirin
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mirin

--- a/src/content/ingredients/mixed-berries.mdx
+++ b/src/content/ingredients/mixed-berries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Mixed Berries
+  - mixed-berries
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Mixed Berries
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mixed Berries

--- a/src/content/ingredients/mixed-salad-greens.mdx
+++ b/src/content/ingredients/mixed-salad-greens.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Mixed Salad Greens
+  - mixed-salad-greens
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Mixed Salad Greens
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mixed Salad Greens

--- a/src/content/ingredients/mortadella.mdx
+++ b/src/content/ingredients/mortadella.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Mortadella
+  - mortadella
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Mortadella
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mortadella

--- a/src/content/ingredients/mullet-bottarga.mdx
+++ b/src/content/ingredients/mullet-bottarga.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Mullet Bottarga
+  - mullet-bottarga
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Mullet Bottarga
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mullet Bottarga

--- a/src/content/ingredients/mussels.mdx
+++ b/src/content/ingredients/mussels.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Mussels
+  - mussels
+allergens:
+  - shellfish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Mussels
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mussels

--- a/src/content/ingredients/mustard.mdx
+++ b/src/content/ingredients/mustard.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Mustard
+  - mustard
+allergens:
+  - mustard
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Mustard
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Mustard

--- a/src/content/ingredients/nduja.mdx
+++ b/src/content/ingredients/nduja.mdx
@@ -1,0 +1,16 @@
+---
+aliases:
+  - ‘Nduja
+  - '''''Nduja'
+  - nduja
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: ‘Nduja
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# ‘Nduja

--- a/src/content/ingredients/nectarine.mdx
+++ b/src/content/ingredients/nectarine.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Ripe Nectarines
+  - nectarine
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Ripe Nectarines
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ripe Nectarines

--- a/src/content/ingredients/nutella.mdx
+++ b/src/content/ingredients/nutella.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Nutella
+  - nutella
+allergens:
+  - dairy
+  - nuts
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Nutella
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Nutella

--- a/src/content/ingredients/nutmeg.mdx
+++ b/src/content/ingredients/nutmeg.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Nutmeg
+  - nutmeg
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Nutmeg
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Nutmeg

--- a/src/content/ingredients/oat-flour.mdx
+++ b/src/content/ingredients/oat-flour.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Oat Flour
+  - oat-flour
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Oat Flour
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Oat Flour

--- a/src/content/ingredients/olive-oil.mdx
+++ b/src/content/ingredients/olive-oil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Olive Oil
+  - olive-oil
+allergens: []
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Olive Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Olive Oil

--- a/src/content/ingredients/onion.mdx
+++ b/src/content/ingredients/onion.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Medium Onion
+  - onion
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Medium Onion
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Medium Onion

--- a/src/content/ingredients/orange-juice.mdx
+++ b/src/content/ingredients/orange-juice.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Orange Juice
+  - orange-juice
+allergens: []
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Orange Juice
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Orange Juice

--- a/src/content/ingredients/oregano.mdx
+++ b/src/content/ingredients/oregano.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Oregano
+  - oregano
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Oregano
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Oregano

--- a/src/content/ingredients/ossobuco.mdx
+++ b/src/content/ingredients/ossobuco.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Ossobuco
+  - ossobuco
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Ossobuco
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Ossobuco

--- a/src/content/ingredients/oyster-mushrooms.mdx
+++ b/src/content/ingredients/oyster-mushrooms.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Oyster Mushrooms
+  - oyster-mushrooms
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Oyster Mushrooms
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Oyster Mushrooms

--- a/src/content/ingredients/oyster-sauce.mdx
+++ b/src/content/ingredients/oyster-sauce.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Oyster Sauce
+  - oyster-sauce
+allergens:
+  - fish
+  - shellfish
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Oyster Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Oyster Sauce

--- a/src/content/ingredients/pancetta.mdx
+++ b/src/content/ingredients/pancetta.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Fresh Pancetta
+  - pancetta
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Fresh Pancetta
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Fresh Pancetta

--- a/src/content/ingredients/panko.mdx
+++ b/src/content/ingredients/panko.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Panko
+  - panko
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Panko
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Panko

--- a/src/content/ingredients/paprika.mdx
+++ b/src/content/ingredients/paprika.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Paprika
+  - paprika
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Paprika
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Paprika

--- a/src/content/ingredients/parmigiano-reggiano.mdx
+++ b/src/content/ingredients/parmigiano-reggiano.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Parmigiano Reggiano DOP
+  - parmigiano-reggiano
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Parmigiano Reggiano DOP
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Parmigiano Reggiano DOP

--- a/src/content/ingredients/parsley.mdx
+++ b/src/content/ingredients/parsley.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Parsley
+  - parsley
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Parsley
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Parsley

--- a/src/content/ingredients/pasta.mdx
+++ b/src/content/ingredients/pasta.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Pasta
+  - pasta
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pasta
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pasta

--- a/src/content/ingredients/peanut-butter.mdx
+++ b/src/content/ingredients/peanut-butter.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Peanut Butter
+  - peanut-butter
+allergens:
+  - peanuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Peanut Butter
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Peanut Butter

--- a/src/content/ingredients/peanut-oil.mdx
+++ b/src/content/ingredients/peanut-oil.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Peanut Oil
+  - peanut-oil
+allergens:
+  - peanuts
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Peanut Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Peanut Oil

--- a/src/content/ingredients/pear.mdx
+++ b/src/content/ingredients/pear.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Pear
+  - pear
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pear
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pear

--- a/src/content/ingredients/pearled-farro.mdx
+++ b/src/content/ingredients/pearled-farro.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Pearled Farro
+  - pearled-farro
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pearled Farro
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pearled Farro

--- a/src/content/ingredients/peas.mdx
+++ b/src/content/ingredients/peas.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Peas
+  - peas
+allergens: []
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Peas
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Peas

--- a/src/content/ingredients/pecorino-romano.mdx
+++ b/src/content/ingredients/pecorino-romano.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Pecorino Romano
+  - pecorino-romano
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Pecorino Romano
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pecorino Romano

--- a/src/content/ingredients/pecorino-sardo.mdx
+++ b/src/content/ingredients/pecorino-sardo.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sardinian Pecorino
+  - pecorino-sardo
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Sardinian Pecorino
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sardinian Pecorino

--- a/src/content/ingredients/peeled-tomatoes.mdx
+++ b/src/content/ingredients/peeled-tomatoes.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Peeled Tomatoes
+  - peeled-tomatoes
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Peeled Tomatoes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Peeled Tomatoes

--- a/src/content/ingredients/pepper.mdx
+++ b/src/content/ingredients/pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Pepper
+  - pepper
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pepper
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pepper

--- a/src/content/ingredients/pine-nuts.mdx
+++ b/src/content/ingredients/pine-nuts.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Pine Nuts
+  - pine-nuts
+allergens:
+  - nuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pine Nuts
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pine Nuts

--- a/src/content/ingredients/pinsa-romana-base.mdx
+++ b/src/content/ingredients/pinsa-romana-base.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Pinsa Romana Base
+  - pinsa-romana-base
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pinsa Romana Base
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pinsa Romana Base

--- a/src/content/ingredients/pistachio.mdx
+++ b/src/content/ingredients/pistachio.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Pistachio
+  - pistachio
+allergens:
+  - nuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pistachio
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pistachio

--- a/src/content/ingredients/plain-yogurt.mdx
+++ b/src/content/ingredients/plain-yogurt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Plain Yogurt
+  - plain-yogurt
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Plain Yogurt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Plain Yogurt

--- a/src/content/ingredients/pork-loin-chops.mdx
+++ b/src/content/ingredients/pork-loin-chops.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Pork Loin Chops
+  - pork-loin-chops
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Pork Loin Chops
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pork Loin Chops

--- a/src/content/ingredients/pork-ribs.mdx
+++ b/src/content/ingredients/pork-ribs.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Pork Ribs
+  - pork-ribs
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Pork Ribs
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pork Ribs

--- a/src/content/ingredients/potato-starch.mdx
+++ b/src/content/ingredients/potato-starch.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Potato Starch
+  - potato-starch
+allergens: []
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Potato Starch
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Potato Starch

--- a/src/content/ingredients/potato.mdx
+++ b/src/content/ingredients/potato.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Medium-Large Potatoes
+  - potato
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Medium-Large Potatoes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Medium-Large Potatoes

--- a/src/content/ingredients/powdered-sugar.mdx
+++ b/src/content/ingredients/powdered-sugar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Powdered Sugar
+  - powdered-sugar
+allergens: []
+category: sweetener
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Powdered Sugar
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Powdered Sugar

--- a/src/content/ingredients/provolone-del-monaco.mdx
+++ b/src/content/ingredients/provolone-del-monaco.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Provolone del Monaco
+  - provolone-del-monaco
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Provolone del Monaco
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Provolone del Monaco

--- a/src/content/ingredients/puff-pastry-sheet.mdx
+++ b/src/content/ingredients/puff-pastry-sheet.mdx
@@ -1,0 +1,20 @@
+---
+aliases:
+  - Round Puff Pastry Sheet
+  - puff-pastry-sheet
+allergens:
+  - dairy
+  - egg
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Round Puff Pastry Sheet
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Round Puff Pastry Sheet

--- a/src/content/ingredients/radicchio.mdx
+++ b/src/content/ingredients/radicchio.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Radicchio
+  - radicchio
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Radicchio
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Radicchio

--- a/src/content/ingredients/raspberries.mdx
+++ b/src/content/ingredients/raspberries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Raspberries
+  - raspberries
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Raspberries
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Raspberries

--- a/src/content/ingredients/rayu-chili-oil.mdx
+++ b/src/content/ingredients/rayu-chili-oil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Rayu Chili Oil
+  - rayu-chili-oil
+allergens: []
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Rayu Chili Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Rayu Chili Oil

--- a/src/content/ingredients/red-bell-pepper.mdx
+++ b/src/content/ingredients/red-bell-pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Red Bell Pepper
+  - red-bell-pepper
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Red Bell Pepper
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Red Bell Pepper

--- a/src/content/ingredients/red-cabbage.mdx
+++ b/src/content/ingredients/red-cabbage.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Red Cabbage
+  - red-cabbage
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Red Cabbage
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Red Cabbage

--- a/src/content/ingredients/red-miso-paste.mdx
+++ b/src/content/ingredients/red-miso-paste.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Red Miso Paste
+  - red-miso-paste
+allergens:
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Red Miso Paste
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Red Miso Paste

--- a/src/content/ingredients/red-onion.mdx
+++ b/src/content/ingredients/red-onion.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Red Onion
+  - red-onion
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Red Onion
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Red Onion

--- a/src/content/ingredients/red-wine.mdx
+++ b/src/content/ingredients/red-wine.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Red Wine
+  - red-wine
+allergens:
+  - sulphites
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Red Wine
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Red Wine

--- a/src/content/ingredients/redcurrants.mdx
+++ b/src/content/ingredients/redcurrants.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Redcurrants
+  - redcurrants
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Redcurrants
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Redcurrants

--- a/src/content/ingredients/rice-vinegar.mdx
+++ b/src/content/ingredients/rice-vinegar.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Rice Vinegar
+  - rice-vinegar
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Rice Vinegar
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Rice Vinegar

--- a/src/content/ingredients/rolled-oats.mdx
+++ b/src/content/ingredients/rolled-oats.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Rolled Oats
+  - rolled-oats
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Rolled Oats
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Rolled Oats

--- a/src/content/ingredients/rosemary.mdx
+++ b/src/content/ingredients/rosemary.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Rosemary
+  - rosemary
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Rosemary
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Rosemary

--- a/src/content/ingredients/saffron.mdx
+++ b/src/content/ingredients/saffron.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Saffron
+  - saffron
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Saffron
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Saffron

--- a/src/content/ingredients/sage.mdx
+++ b/src/content/ingredients/sage.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sage Leaves
+  - sage
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sage Leaves
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sage Leaves

--- a/src/content/ingredients/sake.mdx
+++ b/src/content/ingredients/sake.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sake
+  - sake
+allergens: []
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sake
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sake

--- a/src/content/ingredients/salmon-fillet.mdx
+++ b/src/content/ingredients/salmon-fillet.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Fresh Skinless Salmon Fillet
+  - salmon-fillet
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Fresh Skinless Salmon Fillet
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Fresh Skinless Salmon Fillet

--- a/src/content/ingredients/salt.mdx
+++ b/src/content/ingredients/salt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Salt
+  - salt
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Salt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Salt

--- a/src/content/ingredients/sausage.mdx
+++ b/src/content/ingredients/sausage.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sausage
+  - sausage
+allergens:
+  - dairy
+  - gluten
+  - soy
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Sausage
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sausage

--- a/src/content/ingredients/savoy-cabbage.mdx
+++ b/src/content/ingredients/savoy-cabbage.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Savoy Cabbage
+  - savoy-cabbage
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Savoy Cabbage
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Savoy Cabbage

--- a/src/content/ingredients/sea-salt.mdx
+++ b/src/content/ingredients/sea-salt.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Coarse Sea Salt
+  - sea-salt
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Coarse Sea Salt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Coarse Sea Salt

--- a/src/content/ingredients/seitan.mdx
+++ b/src/content/ingredients/seitan.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Seitan
+  - seitan
+allergens:
+  - gluten
+category: legume
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Seitan
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Seitan

--- a/src/content/ingredients/sesame-oil.mdx
+++ b/src/content/ingredients/sesame-oil.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Sesame Oil
+  - sesame-oil
+allergens:
+  - sesame
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sesame Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sesame Oil

--- a/src/content/ingredients/sesame-or-poppy-seeds.mdx
+++ b/src/content/ingredients/sesame-or-poppy-seeds.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Sesame or Poppy Seeds
+  - sesame-or-poppy-seeds
+allergens:
+  - sesame
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sesame or Poppy Seeds
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sesame or Poppy Seeds

--- a/src/content/ingredients/shallot.mdx
+++ b/src/content/ingredients/shallot.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Shallot
+  - shallot
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Shallot
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Shallot

--- a/src/content/ingredients/sheet-gelatin.mdx
+++ b/src/content/ingredients/sheet-gelatin.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Sheet Gelatin
+  - sheet-gelatin
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Sheet Gelatin
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sheet Gelatin

--- a/src/content/ingredients/shrimp-head.mdx
+++ b/src/content/ingredients/shrimp-head.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Shrimp Head
+  - shrimp-head
+allergens:
+  - shellfish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Shrimp Head
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Shrimp Head

--- a/src/content/ingredients/smoked-paprika.mdx
+++ b/src/content/ingredients/smoked-paprika.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Smoked Paprika
+  - smoked-paprika
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Smoked Paprika
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Smoked Paprika

--- a/src/content/ingredients/smoked-salmon.mdx
+++ b/src/content/ingredients/smoked-salmon.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Smoked Salmon
+  - smoked-salmon
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Smoked Salmon
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Smoked Salmon

--- a/src/content/ingredients/soffritto-mix.mdx
+++ b/src/content/ingredients/soffritto-mix.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Soffritto Mix
+  - soffritto-mix
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Soffritto Mix
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Soffritto Mix

--- a/src/content/ingredients/soy-sauce.mdx
+++ b/src/content/ingredients/soy-sauce.mdx
@@ -1,0 +1,20 @@
+---
+aliases:
+  - Soy Sauce
+  - soy-sauce
+allergens:
+  - gluten
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Soy Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Soy Sauce

--- a/src/content/ingredients/soy-yogurt.mdx
+++ b/src/content/ingredients/soy-yogurt.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Soy Yogurt
+  - soy-yogurt
+allergens:
+  - soy
+category: beverage
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Soy Yogurt
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Soy Yogurt

--- a/src/content/ingredients/spaghetti.mdx
+++ b/src/content/ingredients/spaghetti.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Spaghetti
+  - spaghetti
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Spaghetti
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Spaghetti

--- a/src/content/ingredients/spaghettoni.mdx
+++ b/src/content/ingredients/spaghettoni.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Spaghettoni
+  - spaghettoni
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Spaghettoni
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Spaghettoni

--- a/src/content/ingredients/speck.mdx
+++ b/src/content/ingredients/speck.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Speck Alto Adige IGP
+  - speck
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Speck Alto Adige IGP
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Speck Alto Adige IGP

--- a/src/content/ingredients/spinach.mdx
+++ b/src/content/ingredients/spinach.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Spinach
+  - spinach
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Spinach
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Spinach

--- a/src/content/ingredients/spring-onion.mdx
+++ b/src/content/ingredients/spring-onion.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Spring Onion
+  - spring-onion
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Spring Onion
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Spring Onion

--- a/src/content/ingredients/squid.mdx
+++ b/src/content/ingredients/squid.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Squid
+  - squid
+allergens:
+  - shellfish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Squid
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Squid

--- a/src/content/ingredients/stockfish.mdx
+++ b/src/content/ingredients/stockfish.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Stockfish
+  - stockfish
+allergens:
+  - fish
+category: seafood
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Stockfish
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Stockfish

--- a/src/content/ingredients/strawberries.mdx
+++ b/src/content/ingredients/strawberries.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Fresh Strawberries
+  - strawberries
+allergens: []
+category: fruit
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Fresh Strawberries
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Fresh Strawberries

--- a/src/content/ingredients/sun-dried-tomatoes.mdx
+++ b/src/content/ingredients/sun-dried-tomatoes.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Sun-Dried Tomatoes
+  - sun-dried-tomatoes
+allergens:
+  - sulphites
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sun-Dried Tomatoes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sun-Dried Tomatoes

--- a/src/content/ingredients/sunflower-oil.mdx
+++ b/src/content/ingredients/sunflower-oil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sunflower Oil
+  - sunflower-oil
+allergens: []
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sunflower Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sunflower Oil

--- a/src/content/ingredients/sweet-paprika.mdx
+++ b/src/content/ingredients/sweet-paprika.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sweet Paprika
+  - sweet-paprika
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Sweet Paprika
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sweet Paprika

--- a/src/content/ingredients/sweet-provola.mdx
+++ b/src/content/ingredients/sweet-provola.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Sweet Provola
+  - sweet-provola
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Sweet Provola
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Sweet Provola

--- a/src/content/ingredients/taggiasca-olives.mdx
+++ b/src/content/ingredients/taggiasca-olives.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Pitted Taggiasca Olives
+  - taggiasca-olives
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Pitted Taggiasca Olives
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Pitted Taggiasca Olives

--- a/src/content/ingredients/tahini.mdx
+++ b/src/content/ingredients/tahini.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Tahini
+  - tahini
+allergens:
+  - sesame
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Tahini
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tahini

--- a/src/content/ingredients/taleggio.mdx
+++ b/src/content/ingredients/taleggio.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Taleggio DOP
+  - taleggio
+allergens:
+  - dairy
+category: dairy
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegetarian
+status: seedling
+title: Taleggio DOP
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Taleggio DOP

--- a/src/content/ingredients/thyme.mdx
+++ b/src/content/ingredients/thyme.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Thyme
+  - thyme
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Thyme
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Thyme

--- a/src/content/ingredients/toasted-sesame-oil.mdx
+++ b/src/content/ingredients/toasted-sesame-oil.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Toasted Sesame Oil
+  - toasted-sesame-oil
+allergens:
+  - sesame
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Toasted Sesame Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Toasted Sesame Oil

--- a/src/content/ingredients/toasted-sesame-seeds.mdx
+++ b/src/content/ingredients/toasted-sesame-seeds.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Toasted Sesame Seeds
+  - toasted-sesame-seeds
+allergens:
+  - sesame
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Toasted Sesame Seeds
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Toasted Sesame Seeds

--- a/src/content/ingredients/tomato-passata.mdx
+++ b/src/content/ingredients/tomato-passata.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Tomato Passata
+  - tomato-passata
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Tomato Passata
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tomato Passata

--- a/src/content/ingredients/tomato-paste.mdx
+++ b/src/content/ingredients/tomato-paste.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Double Concentrated Tomato Paste
+  - tomato-paste
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Double Concentrated Tomato Paste
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Double Concentrated Tomato Paste

--- a/src/content/ingredients/tomato.mdx
+++ b/src/content/ingredients/tomato.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Tomatoes
+  - tomato
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Tomatoes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tomatoes

--- a/src/content/ingredients/tonkatsu-sauce.mdx
+++ b/src/content/ingredients/tonkatsu-sauce.mdx
@@ -1,0 +1,17 @@
+---
+aliases:
+  - Tonkatsu Sauce
+  - tonkatsu-sauce
+allergens:
+  - gluten
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Tonkatsu Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tonkatsu Sauce

--- a/src/content/ingredients/tortillas.mdx
+++ b/src/content/ingredients/tortillas.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Tortillas
+  - tortillas
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Tortillas
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tortillas

--- a/src/content/ingredients/turmeric.mdx
+++ b/src/content/ingredients/turmeric.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Turmeric
+  - turmeric
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Turmeric
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Turmeric

--- a/src/content/ingredients/tuscan-kale.mdx
+++ b/src/content/ingredients/tuscan-kale.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Tuscan Kale Leaves
+  - tuscan-kale
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Tuscan Kale Leaves
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Tuscan Kale Leaves

--- a/src/content/ingredients/vanilla-extract.mdx
+++ b/src/content/ingredients/vanilla-extract.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Vanilla Extract
+  - vanilla-extract
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vanilla Extract
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vanilla Extract

--- a/src/content/ingredients/veal-bones.mdx
+++ b/src/content/ingredients/veal-bones.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Veal Bones
+  - veal-bones
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Veal Bones
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Veal Bones

--- a/src/content/ingredients/veal-escalopes.mdx
+++ b/src/content/ingredients/veal-escalopes.mdx
@@ -1,0 +1,15 @@
+---
+aliases:
+  - Veal Escalopes
+  - veal-escalopes
+allergens: []
+category: meat
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+status: seedling
+title: Veal Escalopes
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Veal Escalopes

--- a/src/content/ingredients/vegan-grated-cheese.mdx
+++ b/src/content/ingredients/vegan-grated-cheese.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Vegan Grated Cheese
+  - vegan-grated-cheese
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vegan Grated Cheese
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vegan Grated Cheese

--- a/src/content/ingredients/vegan-ricotta.mdx
+++ b/src/content/ingredients/vegan-ricotta.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Vegan Ricotta
+  - vegan-ricotta
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vegan Ricotta
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vegan Ricotta

--- a/src/content/ingredients/vegetable-oil.mdx
+++ b/src/content/ingredients/vegetable-oil.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Vegetable Oil
+  - vegetable-oil
+allergens: []
+category: fat-oil
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vegetable Oil
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vegetable Oil

--- a/src/content/ingredients/vegetable-stock.mdx
+++ b/src/content/ingredients/vegetable-stock.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Vegetable Stock
+  - vegetable-stock
+allergens: []
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vegetable Stock
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vegetable Stock

--- a/src/content/ingredients/vegetarian-oyster-sauce.mdx
+++ b/src/content/ingredients/vegetarian-oyster-sauce.mdx
@@ -1,0 +1,20 @@
+---
+aliases:
+  - Vegetarian Oyster Sauce
+  - vegetarian-oyster-sauce
+allergens:
+  - gluten
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Vegetarian Oyster Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Vegetarian Oyster Sauce

--- a/src/content/ingredients/walnuts.mdx
+++ b/src/content/ingredients/walnuts.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Walnuts
+  - walnuts
+allergens:
+  - nuts
+category: nut-seed
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Walnuts
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Walnuts

--- a/src/content/ingredients/wasabi-powder.mdx
+++ b/src/content/ingredients/wasabi-powder.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Wasabi Powder
+  - wasabi-powder
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Wasabi Powder
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Wasabi Powder

--- a/src/content/ingredients/water.mdx
+++ b/src/content/ingredients/water.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Water
+  - water
+allergens: []
+category: other
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Water
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Water

--- a/src/content/ingredients/white-cabbage.mdx
+++ b/src/content/ingredients/white-cabbage.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - White Cabbage
+  - white-cabbage
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: White Cabbage
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# White Cabbage

--- a/src/content/ingredients/white-onion.mdx
+++ b/src/content/ingredients/white-onion.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - White Onion
+  - white-onion
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: White Onion
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# White Onion

--- a/src/content/ingredients/white-pepper.mdx
+++ b/src/content/ingredients/white-pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - White Pepper
+  - white-pepper
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: White Pepper
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# White Pepper

--- a/src/content/ingredients/white-peppercorns.mdx
+++ b/src/content/ingredients/white-peppercorns.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - White Peppercorns
+  - white-peppercorns
+allergens: []
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: White Peppercorns
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# White Peppercorns

--- a/src/content/ingredients/white-wine-vinegar.mdx
+++ b/src/content/ingredients/white-wine-vinegar.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - White Wine Vinegar
+  - white-wine-vinegar
+allergens:
+  - sulphites
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: White Wine Vinegar
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# White Wine Vinegar

--- a/src/content/ingredients/whole-wheat-bread.mdx
+++ b/src/content/ingredients/whole-wheat-bread.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Whole Wheat Bread
+  - whole-wheat-bread
+allergens:
+  - gluten
+category: grain
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Whole Wheat Bread
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Whole Wheat Bread

--- a/src/content/ingredients/worcestershire-sauce.mdx
+++ b/src/content/ingredients/worcestershire-sauce.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Worcestershire Sauce
+  - worcestershire-sauce
+allergens:
+  - fish
+  - shellfish
+  - soy
+category: condiment
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+status: seedling
+title: Worcestershire Sauce
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Worcestershire Sauce

--- a/src/content/ingredients/yellow-bell-pepper.mdx
+++ b/src/content/ingredients/yellow-bell-pepper.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Yellow Bell Pepper
+  - yellow-bell-pepper
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Yellow Bell Pepper
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Yellow Bell Pepper

--- a/src/content/ingredients/yellow-mustard-powder.mdx
+++ b/src/content/ingredients/yellow-mustard-powder.mdx
@@ -1,0 +1,19 @@
+---
+aliases:
+  - Yellow Mustard Powder
+  - yellow-mustard-powder
+allergens:
+  - mustard
+category: herb-spice
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Yellow Mustard Powder
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Yellow Mustard Powder

--- a/src/content/ingredients/zucchini.mdx
+++ b/src/content/ingredients/zucchini.mdx
@@ -1,0 +1,18 @@
+---
+aliases:
+  - Zucchini
+  - zucchini
+allergens: []
+category: produce
+createdAt: 2026-05-31T20:08:47.000Z
+diets:
+  - omnivore
+  - pescatarian
+  - vegan
+  - vegetarian
+status: seedling
+title: Zucchini
+updatedAt: 2026-06-01T08:51:47.000Z
+contentType: ingredients
+---
+# Zucchini

--- a/src/content/recipes/aioli-sauce.mdx
+++ b/src/content/recipes/aioli-sauce.mdx
@@ -4,9 +4,27 @@ aliases:
   - aioli-sauce
 createdAt: 2026-03-28T11:20:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
 illustration: images/aioli-sauce.jpg
+ingredient_groups:
+  - ingredients:
+      - id: garlic
+        quantity: 4
+        unit: clove
+        note: large
+      - id: peanut-oil
+        quantity: 300
+        unit: milliliters
+      - id: egg-yolk
+        quantity: 3
+        note: including 1 hard-boiled yolk
+      - id: lemon-juice
+        quantity: 15
+        unit: milliliters
+        note: strained
+      - id: salt
+        note: 'fine, as needed'
+      - id: white-pepper
+        note: as needed
 serves: 4
 status: seedling
 title: Aioli sauce
@@ -14,15 +32,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Large garlic cloves (4)
-- Peanut (groundnut) oil (300 ml)
-- Egg yolks (3, including 1 hard-boiled yolk)
-- Strained lemon juice (15 ml)
-- Fine salt (as needed)
-- White pepper (as needed)
-
 ## Steps
 
 1. Hard-boil an egg, then remove the yolk.

--- a/src/content/recipes/aloo-gobi.mdx
+++ b/src/content/recipes/aloo-gobi.mdx
@@ -4,8 +4,50 @@ aliases:
   - aloo-gobi
 createdAt: 2025-12-28T19:10:00.000Z
 cuisine: indian
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 4
+      - id: cauliflower
+        quantity: 1
+      - id: onion
+        quantity: 1
+      - id: peeled-tomatoes
+        quantity: 2
+        unit: can
+      - id: ground-cumin
+        quantity: 5
+        unit: milliliters
+      - id: fresh-ginger
+        quantity: 2
+        unit: cm
+        note: grated
+      - id: garlic
+        quantity: 2
+        unit: clove
+        note: grated
+      - id: ground-turmeric
+        quantity: 5
+        unit: milliliters
+      - id: ground-garam-masala
+        quantity: 1
+        unit: pinch
+      - id: ground-coriander
+        quantity: 5
+        unit: milliliters
+      - id: vegetable-oil
+        quantity: 75
+        unit: milliliters
+      - id: peas
+        quantity: 100
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: coconut-milk
+        quantity: 200
+        unit: grams
+      - id: fresh-cilantro
+        note: to serve
 serves: 4
 status: evergreen
 title: Aloo gobi
@@ -13,24 +55,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Medium-large potatoes (4)
-- Medium cauliflower (1)
-- Medium onion (1)
-- Peeled tomatoes (2 cans)
-- Ground cumin (5 ml)
-- Fresh ginger (2 cm, grated)
-- Garlic cloves (2, grated)
-- Ground turmeric (5 ml)
-- Ground garam masala (1 pinch)
-- Ground coriander (5 ml)
-- Vegetable oil (75 ml)
-- Peas (100 g)
-- Salt (as needed)
-- Coconut milk (200 g)
-- Fresh cilantro (to serve)
-
 ## Steps
 
 1. Cut the cauliflower into florets and rinse under running water.

--- a/src/content/recipes/apple-cake.mdx
+++ b/src/content/recipes/apple-cake.mdx
@@ -4,8 +4,41 @@ aliases:
   - apple-cake
 createdAt: 2026-03-29T08:41:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Batter
+    ingredients:
+      - id: golden-apple
+        quantity: 1000
+        unit: grams
+      - id: egg
+        quantity: 4
+      - id: granulated-sugar
+        quantity: 180
+        unit: grams
+      - id: lemon-zest
+        quantity: 1
+        unit: lemon
+      - id: all-purpose-flour
+        quantity: 240
+        unit: grams
+      - id: baking-powder
+        quantity: 16
+        unit: grams
+      - id: extra-virgin-olive-oil
+        quantity: 120
+        unit: grams
+      - id: salt
+        note: to taste
+      - id: ground-cinnamon
+        note: to taste
+  - group: Decoration
+    ingredients:
+      - id: granulated-sugar
+        quantity: 30
+        unit: grams
+      - id: powdered-sugar
+        quantity: 5
+        unit: grams
 serves: 8
 status: evergreen
 title: Apple cake
@@ -13,23 +46,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the batter:
-
-- Golden apples (1 kg)
-- Eggs (4)
-- Granulated sugar (180 g)
-- Lemon zest (1 lemon)
-- All-purpose flour (240 g)
-- Baking powder (16 g)
-- Extra virgin olive oil (120 g)
-- Fine salt (to taste)
-- Ground cinnamon (to taste)
-For decoration:
-- Granulated sugar (30 g)
-- Powdered sugar (5 g)
-
 ## Steps
 
 1. Crack the eggs into a large bowl, add the sugar and beat with an electric mixer until the mixture is light, fluffy and pale.

--- a/src/content/recipes/banana-bread.mdx
+++ b/src/content/recipes/banana-bread.mdx
@@ -4,8 +4,42 @@ aliases:
   - banana-bread
 createdAt: 2026-04-19T16:11:00.000Z
 cuisine: american
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Batter
+    ingredients:
+      - id: banana
+        quantity: 450
+        unit: grams
+        note: about 4 bananas
+      - id: all-purpose-flour
+        quantity: 200
+        unit: grams
+      - id: butter
+        quantity: 120
+        unit: grams
+        note: softened
+      - id: granulated-sugar
+        quantity: 120
+        unit: grams
+      - id: egg
+        quantity: 2
+        note: medium
+      - id: baking-powder
+        quantity: 6
+        unit: grams
+      - id: chocolate-chips
+        note: to taste
+      - id: salt
+        quantity: 1
+        unit: pinch
+      - id: lemon-juice
+        note: ½ lemon
+  - group: Pan
+    ingredients:
+      - id: butter
+        note: as needed
+      - id: all-purpose-flour
+        note: as needed
 serves: 6
 status: evergreen
 title: Banana bread
@@ -13,23 +47,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the batter:
-
-- Ripe banana flesh (450 g, about 4 bananas)
-- All-purpose flour (00) (200 g)
-- Softened butter (120 g)
-- Sugar (120 g)
-- Eggs (110 g, 2 medium)
-- Baking powder (6 g)
-- Chocolate chips (to taste)
-- Fine salt (1 pinch)
-- Lemon juice (½ lemon)
-For the pan:
-- Butter (as needed)
-- All-purpose flour (00) (as needed)
-
 ## Steps
 
 1. Squeeze the juice of half a lemon.

--- a/src/content/recipes/banana-pancakes-with-strawberries.mdx
+++ b/src/content/recipes/banana-pancakes-with-strawberries.mdx
@@ -4,8 +4,42 @@ aliases:
   - banana-pancakes-with-strawberries
 createdAt: 2025-12-29T11:35:00.000Z
 cuisine: american
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: 00-flour
+        quantity: 215
+        unit: grams
+      - id: baking-powder
+        quantity: 10
+        unit: milliliters
+      - id: ground-cinnamon
+        quantity: 5
+        unit: milliliters
+      - id: salt
+        quantity: 1
+        unit: pinch
+      - id: banana
+        quantity: 240
+        unit: grams
+        note: 'mashed, about 2 large bananas'
+      - id: egg
+        quantity: 2
+        note: room temperature
+      - id: milk
+        quantity: 240
+        unit: milliliters
+        note: room temperature
+      - id: butter
+        quantity: 30
+        unit: milliliters
+        note: melted and cooled
+      - id: vanilla-extract
+        quantity: 5
+        unit: milliliters
+      - id: strawberries
+        quantity: 145
+        unit: grams
+        note: chopped
 serves: 4
 status: evergreen
 title: Banana pancakes with strawberries
@@ -13,19 +47,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- 00 flour (215 g)
-- Baking powder (10 ml)
-- Cinnamon (5 ml)
-- Salt (1 pinch)
-- Mashed ripe banana (240 g, about 2 large bananas)
-- Eggs (2, room temperature)
-- Milk (240 ml, room temperature)
-- Butter (30 ml, melted and cooled)
-- Vanilla extract (5 ml)
-- Fresh strawberries (145 g, chopped)
-
 ## Steps
 
 1. In a large bowl, mix the dry ingredients: flour, baking powder, cinnamon, and salt.

--- a/src/content/recipes/bao-buns.mdx
+++ b/src/content/recipes/bao-buns.mdx
@@ -4,8 +4,26 @@ aliases:
   - bao-buns
 createdAt: 2026-01-11T16:19:00.000Z
 cuisine: asian
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: all-purpose-flour
+        quantity: 500
+        unit: grams
+      - id: fresh-bakers-yeast
+        quantity: 15
+        unit: grams
+      - id: granulated-sugar
+        quantity: 5
+        unit: milliliters
+      - id: water
+        quantity: 300
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        quantity: 15
+        unit: milliliters
+      - id: salt
+        quantity: 5
+        unit: milliliters
 serves: 4
 status: budding
 title: Bao buns
@@ -13,15 +31,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- All-purpose flour (500 g)
-- Fresh baker’s yeast (15 g)
-- Sugar (5 ml)
-- Water (300 ml)
-- Extra virgin olive oil (15 ml)
-- Fine salt (5 ml)
-
 ## Steps
 
 1. In a large bowl, add the flour.

--- a/src/content/recipes/basmati-rice-with-seared-salmon-wakame-and-poached-egg.mdx
+++ b/src/content/recipes/basmati-rice-with-seared-salmon-wakame-and-poached-egg.mdx
@@ -4,31 +4,50 @@ aliases:
   - basmati-rice-with-seared-salmon-wakame-and-poached-egg
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: asian
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: basmati-rice
+        quantity: 160
+        unit: grams
+      - id: salmon-fillet
+        quantity: 200
+        unit: grams
+      - id: egg
+        quantity: 2
+        note: very fresh
+      - id: dried-wakame
+        quantity: 15
+        unit: milliliters
+      - id: light-soy-sauce
+        quantity: 15
+        unit: milliliters
+      - id: mirin
+        quantity: 5
+        unit: milliliters
+        note: or dry white wine
+      - id: toasted-sesame-oil
+        quantity: 5
+        unit: milliliters
+      - id: rice-vinegar
+        quantity: 5
+        unit: milliliters
+        note: or apple cider vinegar
+      - 'id: toasted-sesame-seeds'
+      - id: spring-onion
+        note: thinly sliced
+      - id: fresh-ginger
+        note: grated
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
 serves: 2
 status: budding
 title: 'Basmati rice with seared salmon, wakame, and poached egg'
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:30.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Basmati rice (160 g)
-- Fresh skinless salmon fillet (200 g)
-- Very fresh eggs (2)
-- Dried wakame (15 ml)
-- Light soy sauce (15 ml)
-- Mirin (5 ml, or dry white wine)
-- Toasted sesame oil (5 ml)
-- Rice vinegar (5 ml, or apple cider vinegar)
-- Toasted sesame seeds
-- Spring onion (thinly sliced)
-- Fresh ginger (grated)
-- Salt (to taste)
-- Pepper (to taste)
-
 ## Steps
 
 1. Rinse the basmati until the water runs clear.

--- a/src/content/recipes/bbq-chicken-wings.mdx
+++ b/src/content/recipes/bbq-chicken-wings.mdx
@@ -4,8 +4,23 @@ aliases:
   - bbq-chicken-wings
 createdAt: 2025-12-28T19:06:00.000Z
 cuisine: bbq
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: chicken-wings
+        quantity: 12
+        note: cut into sections
+      - id: barbecue-sauce
+        quantity: 300
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        quantity: 60
+        unit: milliliters
+      - id: salt
+        quantity: 15
+        unit: milliliters
+      - id: chili-flakes
+        quantity: 1
+        unit: pinch
 serves: 2
 status: evergreen
 title: BBQ chicken wings
@@ -13,14 +28,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Chicken wings (12, cut into sections)
-- Barbecue sauce (300 ml)
-- Extra-virgin olive oil (60 ml)
-- Salt (15 ml)
-- Chili flakes (1 pinch)
-
 ## Steps
 
 1. In a bowl, toss the wings with half the BBQ sauce, the olive oil, salt, and chili (add more chili if you want it spicier).

--- a/src/content/recipes/bbq-pork-ribs.mdx
+++ b/src/content/recipes/bbq-pork-ribs.mdx
@@ -4,26 +4,38 @@ aliases:
   - bbq-pork-ribs
 createdAt: 2026-05-23T17:29:00.000Z
 cuisine: bbq
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pork-ribs
+        quantity: 2000
+        unit: grams
+      - id: sweet-paprika
+        quantity: 5
+        unit: grams
+      - id: chilli-powder
+        quantity: 5
+        unit: grams
+      - id: garlic-powder
+        quantity: 5
+        unit: grams
+      - id: yellow-mustard-powder
+        quantity: 5
+        unit: grams
+      - id: ground-cumin
+        quantity: 5
+        unit: grams
+      - id: salt
+        quantity: 5
+        unit: grams
+        note: fine
+      - 'note: ''Ingredients for [[bbq-sauce|BBQ Sauce]]'''
 serves: 4
 status: evergreen
 title: BBQ Pork Ribs
 type: main-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:30.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pork ribs (2 kg)
-- Sweet paprika (5 g)
-- Chilli powder (5 g)
-- Garlic powder (5 g)
-- Yellow mustard powder (5 g)
-- Cumin (5 g)
-- Fine salt (5 g)
-- Ingredients for [[bbq-sauce|BBQ Sauce]]
-
 ## Steps
 
 1. Prepare the sauce following the instructions for the [[bbq-sauce|BBQ Sauce]].

--- a/src/content/recipes/bbq-sauce.mdx
+++ b/src/content/recipes/bbq-sauce.mdx
@@ -4,8 +4,44 @@ aliases:
   - bbq-sauce
 createdAt: 2026-05-23T17:30:00.000Z
 cuisine: bbq
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: onion
+        quantity: 0.5
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: brown-sugar
+        quantity: 10
+        unit: grams
+      - id: maple-syrup
+        quantity: 90
+        unit: grams
+      - id: ketchup
+        quantity: 250
+        unit: grams
+      - id: hot-paprika
+        quantity: 5
+        unit: grams
+      - id: sweet-paprika
+        quantity: 5
+        unit: grams
+      - id: apple-cider-vinegar
+        quantity: 10
+        unit: milliliters
+      - id: mustard
+        quantity: 5
+        unit: grams
+      - id: worcestershire-sauce
+        quantity: 10
+        unit: milliliters
+      - id: pepper
+        quantity: 2
+        unit: grams
+      - id: salt
+        unit: pinch
+      - id: extra-virgin-olive-oil
+        note: a drizzle
 serves: 4
 status: evergreen
 title: BBQ Sauce
@@ -13,22 +49,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Golden onion (½)
-- Garlic (1 clove)
-- Brown sugar (10 g)
-- Maple syrup (90 g)
-- Ketchup (250 g)
-- Hot paprika (5 g)
-- Sweet paprika (5 g)
-- Apple cider vinegar (10 ml)
-- Mustard (5 g)
-- Worcestershire sauce (10 ml)
-- Black pepper (2 g)
-- Fine salt (a pinch)
-- Extra virgin olive oil (a drizzle)
-
 ## Steps
 
 1. Finely chop the onion and garlic.

--- a/src/content/recipes/beef-stew.mdx
+++ b/src/content/recipes/beef-stew.mdx
@@ -4,8 +4,44 @@ aliases:
   - beef-stew
 createdAt: 2025-12-28T19:24:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: beef-chuck
+        quantity: 1000
+        unit: grams
+      - id: beef-stock
+        quantity: 2500
+        unit: milliliters
+      - id: onion
+        quantity: 1
+      - id: carrot
+        quantity: 1
+      - id: celery-stalk
+        quantity: 1
+      - id: red-wine
+        quantity: 1
+        unit: glass
+      - id: extra-virgin-olive-oil
+        quantity: 60
+        unit: milliliters
+      - id: butter
+        quantity: 30
+        unit: grams
+      - id: 00-flour
+        quantity: 30
+        unit: grams
+      - id: rosemary
+        quantity: 1
+        unit: sprig
+      - id: thyme
+        quantity: 1
+        unit: sprig
+      - id: sage
+        quantity: 3
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
 serves: 4
 status: evergreen
 title: Beef stew
@@ -13,23 +49,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Beef chunks (1 kg)
-- Beef stock (2.5 lt)
-- Onion (1)
-- Carrot (1)
-- Celery stalk (1)
-- Red wine (1 glass)
-- Extra-virgin olive oil (60 ml)
-- Butter (30 g)
-- 00 flour (30 g)
-- Rosemary (1 sprig)
-- Thyme (1 sprig)
-- Sage leaves (3)
-- Salt (to taste)
-- Pepper (to taste)
-
 ## Steps
 
 1. Heat the beef stock and keep it warm (you’ll need about 2–2.5 lt).

--- a/src/content/recipes/beef-tenderloin-with-green-peppercorn-sauce.mdx
+++ b/src/content/recipes/beef-tenderloin-with-green-peppercorn-sauce.mdx
@@ -4,8 +4,33 @@ aliases:
   - beef-tenderloin-with-green-peppercorn-sauce
 createdAt: 2025-12-28T19:01:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: beef-tenderloin
+        quantity: 2
+        note: 250–300 g each
+      - id: green-peppercorns-brine
+        quantity: 20
+        unit: grams
+      - id: heavy-cream
+        quantity: 200
+        unit: grams
+      - id: dijon-mustard
+        quantity: 100
+        unit: grams
+      - id: beef-stock
+        quantity: 240
+        unit: grams
+      - id: brandy
+        quantity: 30
+        unit: grams
+      - id: clarified-butter
+        quantity: 40
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: 00-flour
+        note: as needed
 serves: 2
 status: evergreen
 title: Beef tenderloin with green peppercorn sauce
@@ -13,18 +38,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Whole beef tenderloin steaks (2, 250–300 g each)
-- Green peppercorns in brine (20 g)
-- Fresh heavy cream (200 g)
-- Dijon mustard (100 g)
-- Beef stock (240 g)
-- Brandy (30 g)
-- Clarified butter (40 g)
-- Salt (as needed)
-- 00 flour (as needed)
-
 ## Steps
 
 1. Make the beef stock and keep it warm. Make sure all ingredients are at room temperature.

--- a/src/content/recipes/black-bean-salad.mdx
+++ b/src/content/recipes/black-bean-salad.mdx
@@ -4,8 +4,51 @@ aliases:
   - black-bean-salad
 createdAt: 2025-12-28T19:07:00.000Z
 cuisine: tex-mex
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: corn
+        quantity: 2
+        unit: can
+        note: '285 g each, rinsed'
+      - id: black-beans
+        quantity: 2
+        unit: can
+        note: '425 g each, rinsed and drained'
+      - id: red-bell-pepper
+        quantity: 2
+        note: diced
+      - id: garlic
+        quantity: 2
+        unit: clove
+        note: minced
+      - id: shallot
+        quantity: 30
+        unit: milliliters
+        note: chopped
+      - id: salt
+        quantity: 10
+        unit: milliliters
+      - id: cayenne-pepper
+        quantity: 1.25
+        unit: milliliters
+      - id: granulated-sugar
+        quantity: 30
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        quantity: 135
+        unit: milliliters
+      - id: lime-zest
+        quantity: 5
+        unit: milliliters
+      - id: lime-juice
+        quantity: 90
+        unit: milliliters
+      - id: fresh-cilantro
+        quantity: 120
+        unit: milliliters
+        note: chopped
+      - id: avocado
+        quantity: 2
 serves: 6
 status: evergreen
 title: Black bean salad
@@ -13,22 +56,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Corn (2 cans, 285 g each, rinsed)
-- Black beans (2 cans, 425 g each, rinsed and drained)
-- Red bell peppers (2, diced)
-- Garlic cloves (2, minced)
-- Chopped shallot (30 ml)
-- Salt (10 ml)
-- Cayenne pepper (1.25 ml)
-- Sugar (30 ml)
-- Extra-virgin olive oil (135 ml)
-- Lime zest (5 ml)
-- Lime juice (90 ml)
-- Chopped fresh cilantro (120 ml)
-- Avocados (2)
-
 ## Steps
 
 1. Rinse and drain the black beans and corn.

--- a/src/content/recipes/blueberry-risotto-with-taleggio-and-crispy-speck.mdx
+++ b/src/content/recipes/blueberry-risotto-with-taleggio-and-crispy-speck.mdx
@@ -4,30 +4,42 @@ aliases:
   - blueberry-risotto-with-taleggio-and-crispy-speck
 createdAt: 2025-12-27T19:24:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: carnaroli-rice
+        quantity: 320
+        unit: grams
+      - id: blueberries
+        quantity: 320
+        unit: grams
+        note: 70 g small ones to freeze + 250 g for the purée
+      - id: taleggio
+        quantity: 150
+        unit: grams
+      - id: parmigiano-reggiano
+        quantity: 100
+        unit: grams
+      - id: butter
+        quantity: 100
+        unit: grams
+      - id: speck
+        quantity: 4
+        unit: slice
+      - id: shallot
+        quantity: 1
+      - 'id: lemon-thyme'
+      - 'id: extra-virgin-olive-oil'
+      - 'id: dry-white-wine'
+      - 'id: vegetable-stock'
+      - id: salt
+        note: as needed
 serves: 4
 status: budding
 title: Blueberry risotto with taleggio and crispy speck
 type: first-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:30.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Carnaroli rice (320 g)
-- Blueberries (320 g, 70 g small ones to freeze + 250 g for the purée)
-- Taleggio DOP (150 g)
-- Parmigiano Reggiano DOP (100 g)
-- Butter (100 g)
-- Speck Alto Adige IGP (4 slices)
-- Shallot (1)
-- Lemon thyme
-- Extra-virgin olive oil
-- Dry white wine
-- Vegetable stock
-- Salt (as needed)
-
 ## Steps
 
 1. Pick about 70 g of small blueberries and freeze them on a tray.

--- a/src/content/recipes/bolognese-lasagna.mdx
+++ b/src/content/recipes/bolognese-lasagna.mdx
@@ -4,8 +4,80 @@ aliases:
   - bolognese-lasagna
 createdAt: 2026-03-28T11:20:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - group: Green egg pasta sheets
+    ingredients:
+      - id: durum-wheat-semolina
+        quantity: 175
+        unit: grams
+      - id: 00-flour
+        quantity: 75
+        unit: grams
+      - id: spinach
+        quantity: 125
+        unit: grams
+      - id: egg
+        quantity: 1
+      - id: egg-yolk
+        quantity: 2
+  - group: Bolognese ragù
+    ingredients:
+      - id: ground-beef
+        quantity: 700
+        unit: grams
+      - id: pancetta
+        quantity: 270
+        unit: grams
+      - id: tomato-passata
+        quantity: 350
+        unit: grams
+      - id: tomato-paste
+        quantity: 30
+        unit: milliliters
+      - id: carrot
+        quantity: 110
+        unit: grams
+      - id: celery-stalk
+        quantity: 110
+        unit: grams
+      - id: onion
+        quantity: 110
+        unit: grams
+      - id: vegetable-stock
+        quantity: 350
+        unit: grams
+      - id: red-wine
+        quantity: 110
+        unit: grams
+      - id: extra-virgin-olive-oil
+        quantity: 90
+        unit: milliliters
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+  - group: Béchamel
+    ingredients:
+      - id: milk
+        quantity: 800
+        unit: grams
+      - id: butter
+        quantity: 50
+        unit: grams
+      - id: 00-flour
+        quantity: 50
+        unit: grams
+      - id: nutmeg
+        note: as needed
+      - id: salt
+        note: as needed
+  - group: To assemble
+    ingredients:
+      - id: parmigiano-reggiano
+        quantity: 150
+        unit: grams
+      - id: butter
+        note: as needed
 serves: 8
 status: seedling
 title: Bolognese lasagna
@@ -13,38 +85,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the green egg pasta sheets:
-
-- Remilled durum wheat semolina (175 g)
-- 00 flour (75 g)
-- Spinach (125 g)
-- Whole egg (1)
-- Egg yolks (2)
-For the bolognese ragù:
-- Ground beef (700 g)
-- Fresh pancetta (270 g)
-- Tomato passata (350 g)
-- Double concentrated tomato paste (30 ml)
-- Carrots (110 g)
-- Celery (110 g)
-- Golden onions (110 g)
-- Vegetable stock (350 g)
-- Red wine (110 g)
-- Extra-virgin olive oil (90 ml)
-- Fine salt (as needed)
-- Black pepper (as needed)
-For the béchamel:
-- Whole milk (800 g)
-- Butter (50 g)
-- 00 flour (50 g)
-- Nutmeg (as needed)
-- Fine salt (as needed)
-To assemble:
-- Grated Parmigiano Reggiano DOP (150 g)
-- Butter (as needed)
-
 ## Steps
 
 1. Finely chop the onion, celery, and carrot.

--- a/src/content/recipes/breakfast-smoothie-with-banana-oats-and-peanut-butter.mdx
+++ b/src/content/recipes/breakfast-smoothie-with-banana-oats-and-peanut-butter.mdx
@@ -4,25 +4,34 @@ aliases:
   - breakfast-smoothie-with-banana-oats-and-peanut-butter
 createdAt: 2025-12-28T19:13:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: banana
+        note: '1 piece, 100–120 g'
+      - id: banana-whey-protein
+        quantity: 50
+        unit: grams
+      - id: peanut-butter
+        quantity: 20
+        unit: grams
+      - id: rolled-oats
+        quantity: 40
+        unit: grams
+      - id: ground-cinnamon
+        note: 30–45 ml
+      - id: milk
+        unit: milliliters
+        note: '250–270 ml, dairy or plant-based'
+      - id: ice-cubes
+        unit: piece
+        note: 4–5
 serves: 1
 status: evergreen
 title: 'Breakfast smoothie with banana, oats, and peanut butter'
 type: main-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Banana (1, 100–120 g)
-- Banana whey protein (50 g)
-- Peanut butter (20 g)
-- Rolled oats (40 g)
-- Cinnamon (30–45 ml)
-- Milk (250–270 ml, dairy or plant-based)
-- Ice cubes (4–5)
-
 ## Steps
 
 1. Blend everything in a Nutribullet for 30–45 seconds.

--- a/src/content/recipes/brie-and-caramelized-peach-salad.mdx
+++ b/src/content/recipes/brie-and-caramelized-peach-salad.mdx
@@ -4,8 +4,39 @@ aliases:
   - brie-and-caramelized-peach-salad
 createdAt: 2025-12-28T19:11:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Salad
+    ingredients:
+      - id: mixed-salad-greens
+        quantity: 60
+        unit: grams
+        note: 'baby lettuce, arugula, baby spinach'
+      - id: nectarine
+        quantity: 2
+      - id: brie
+        quantity: 100
+        unit: grams
+      - id: walnuts
+        quantity: 30
+        unit: grams
+      - id: brown-sugar
+        quantity: 30
+        unit: milliliters
+  - group: Dressing
+    ingredients:
+      - id: extra-virgin-olive-oil
+        quantity: 45
+        unit: milliliters
+      - id: honey
+        quantity: 30
+        unit: milliliters
+        note: 15 ml for the dressing + 15 ml to finish
+      - id: apple-cider-vinegar
+        quantity: 15
+        unit: milliliters
+        note: or balsamic vinegar
+      - id: salt
+        note: as needed
 serves: 2
 status: evergreen
 title: Brie and caramelized peach salad
@@ -13,23 +44,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the salad:
-
-- Mixed salad greens (60 g, baby lettuce, arugula, baby spinach)
-- Ripe nectarines (2)
-- Brie (100 g)
-- Walnuts (30 g)
-- Brown sugar (30 ml)
-
-For the dressing:
-
-- Extra-virgin olive oil (45 ml)
-- Honey (30 ml, 15 ml for the dressing + 15 ml to finish)
-- Apple cider vinegar or balsamic vinegar (15 ml)
-- Fine salt (as needed)
-
 ## Steps
 
 1. Wash the peaches and cut them into slices that are not too thin, leaving the skin on.

--- a/src/content/recipes/burrito-with-black-bean-salad.mdx
+++ b/src/content/recipes/burrito-with-black-bean-salad.mdx
@@ -4,20 +4,17 @@ aliases:
   - burrito-with-black-bean-salad
 createdAt: 2025-12-28T19:09:00.000Z
 cuisine: tex-mex
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - 'note: ''Ingredients for [[black-bean-salad|Black bean salad]]'''
+      - 'id: tortillas'
 serves: 8
 status: evergreen
 title: Burrito with black bean salad
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ingredients for [[black-bean-salad|Black bean salad]]
-- Tortillas
-
 ## Steps
 
 1. Make [[black-bean-salad|Black bean salad]].

--- a/src/content/recipes/cacio-e-pepe-spaghetti-with-pears.mdx
+++ b/src/content/recipes/cacio-e-pepe-spaghetti-with-pears.mdx
@@ -4,20 +4,20 @@ aliases:
   - cacio-e-pepe-spaghetti-with-pears
 createdAt: 2025-12-28T18:56:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - >-
+        note: 'Ingredients for [[spaghetti-cacio-e-pepe|Spaghetti cacio e
+        pepe]]'
+      - id: pear
+        quantity: 1
 serves: 1
 status: evergreen
 title: Cacio e pepe spaghetti with pears
 type: first-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ingredients for [[spaghetti-cacio-e-pepe|Spaghetti cacio e pepe]]
-- Pear (1)
-
 ## Steps
 
 1. Peel the pear and cut it into small cubes (as if it were guanciale).

--- a/src/content/recipes/calamari-con-peperoni-olive-e-capperi.mdx
+++ b/src/content/recipes/calamari-con-peperoni-olive-e-capperi.mdx
@@ -4,28 +4,44 @@ aliases:
   - calamari-con-peperoni-olive-e-capperi
 createdAt: 2026-04-17T16:53:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: squid
+        quantity: 400
+        unit: grams
+      - id: yellow-bell-pepper
+        quantity: 200
+        unit: grams
+      - id: red-bell-pepper
+        quantity: 200
+        unit: grams
+      - id: capers
+        quantity: 15
+        unit: milliliters
+      - id: green-olives
+        quantity: 10
+        note: pitted
+      - id: parsley
+        note: to taste
+      - id: salt
+        quantity: 1
+        unit: pinch
+      - id: pepper
+        quantity: 1
+        unit: pinch
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        quantity: 50
+        unit: milliliters
 serves: 2
 status: budding
 title: 'Calamari con peperoni, olive e capperi'
 type: main-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Squid (400 g)
-- Yellow bell peppers (200 g)
-- Red bell peppers (200 g)
-- Capers (15 ml)
-- Green olives (10, pitted)
-- Parsley (to taste)
-- Salt (1 pinch)
-- Pepper (1 pinch)
-- Garlic (1 clove)
-- Extra virgin olive oil (50 ml)
-
 ## Steps
 
 1. Clean the squid: detach the tentacles from the bodies, remove the eyes and the central beak (between the tentacles), remove the innards and cartilage from the bodies, then peel them. Cut everything into rings, rinse under running water, and pat dry well with kitchen paper.

--- a/src/content/recipes/carbonara-pinsa.mdx
+++ b/src/content/recipes/carbonara-pinsa.mdx
@@ -4,8 +4,32 @@ aliases:
   - carbonara-pinsa
 createdAt: 2025-12-28T19:15:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - group: Topping
+    ingredients:
+      - id: egg
+        quantity: 3
+        note: medium whole
+      - id: egg-yolk
+        quantity: 6
+      - id: parmigiano-reggiano
+        quantity: 60
+        unit: grams
+        note: grated
+      - id: pecorino-romano
+        quantity: 30
+        unit: grams
+        note: grated
+      - id: pepper
+        note: 'as needed, black'
+      - id: guanciale
+        quantity: 150
+        unit: grams
+        note: sliced
+      - id: pecorino-romano
+        quantity: 45
+        unit: grams
+        note: shaved
 serves: 3
 status: evergreen
 title: Carbonara pinsa
@@ -13,18 +37,6 @@ type: single-dish
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the topping:
-
-- Medium whole eggs (3)
-- Egg yolks (6)
-- Grated Parmigiano Reggiano (60 g)
-- Grated pecorino romano (30 g)
-- Black pepper (as needed)
-- Sliced guanciale (150 g)
-- Pecorino romano (45 g, shaved)
-
 ## Steps
 
 1. Use a vegetable peeler to shave the pecorino.

--- a/src/content/recipes/cauliflower-steak.mdx
+++ b/src/content/recipes/cauliflower-steak.mdx
@@ -4,8 +4,27 @@ aliases:
   - cauliflower-steak
 createdAt: 2025-12-28T18:54:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: cauliflower
+        quantity: 1
+        note: large
+      - id: extra-virgin-olive-oil
+        quantity: 45
+        unit: milliliters
+      - id: smoked-paprika
+        quantity: 5
+        unit: milliliters
+        note: 'or curry, or both'
+      - id: salt
+        note: 'coarse, to taste'
+      - id: pepper
+        note: to taste
+      - id: lemon-juice
+        quantity: 0.5
+        note: from lemon
+      - id: parsley
+        note: 'fresh, chopped, to taste'
 serves: 4
 status: evergreen
 title: Cauliflower steak
@@ -13,16 +32,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Large cauliflower (1)
-- Extra-virgin olive oil (45 ml)
-- Smoked paprika (5 ml, or curry, or both)
-- Coarse salt (to taste)
-- Pepper (to taste)
-- Lemon juice (½ lemon)
-- Chopped fresh parsley (to taste)
-
 ## Steps
 
 1. Heat the oven to 200 °C (fan if possible).

--- a/src/content/recipes/chicken-burrito-with-lime-guacamole.mdx
+++ b/src/content/recipes/chicken-burrito-with-lime-guacamole.mdx
@@ -4,8 +4,70 @@ aliases:
   - chicken-burrito-with-lime-guacamole
 createdAt: 2025-12-28T19:08:00.000Z
 cuisine: tex-mex
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: tortillas
+        quantity: 4
+      - id: chicken-breast
+        quantity: 400
+        unit: grams
+        note: sliced
+      - id: lettuce
+        quantity: 80
+        unit: grams
+      - id: black-beans
+        quantity: 150
+        unit: grams
+        note: cooked
+      - id: cheddar
+        quantity: 200
+        unit: grams
+        note: sliced
+      - id: tomato
+        quantity: 200
+        unit: grams
+  - group: Marinade
+    ingredients:
+      - id: extra-virgin-olive-oil
+        quantity: 30
+        unit: grams
+      - id: lime-juice
+        quantity: 10
+        unit: grams
+      - id: lime-zest
+        quantity: 1
+      - id: salt
+        note: as needed
+      - id: cayenne-pepper
+        quantity: 1
+        unit: grams
+      - id: honey
+        quantity: 20
+        unit: grams
+  - group: Guacamole
+    ingredients:
+      - id: avocado
+        quantity: 1
+        note: ripe
+      - id: shallot
+        quantity: 10
+        unit: grams
+      - id: fresh-chili
+        quantity: 10
+        unit: grams
+      - id: tomato
+        quantity: 150
+        unit: grams
+      - id: lime-juice
+        quantity: 10
+        unit: grams
+      - id: extra-virgin-olive-oil
+        quantity: 20
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
 serves: 4
 status: evergreen
 title: Chicken burrito with lime guacamole
@@ -13,31 +75,6 @@ type: single-dish
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Tortillas (4)
-- Sliced chicken breast (400 g)
-- Lettuce (80 g)
-- Cooked black beans (150 g)
-- Sliced cheddar (200 g)
-- Tomatoes (200 g)
-For the marinade:
-- Extra-virgin olive oil (30 g)
-- Lime juice (10 g)
-- Lime zest (1 lime)
-- Salt (as needed)
-- Cayenne pepper (1 g)
-- Honey (20 g)
-For the guacamole:
-- Ripe avocado (1)
-- Shallot (10 g)
-- Fresh chili (10 g)
-- Tomatoes (150 g)
-- Lime juice (10 g)
-- Extra-virgin olive oil (20 g)
-- Salt (as needed)
-- Pepper (as needed)
-
 ## Steps
 
 1. Mash the avocado.

--- a/src/content/recipes/chicken-cacciatore.mdx
+++ b/src/content/recipes/chicken-cacciatore.mdx
@@ -4,8 +4,40 @@ aliases:
   - chicken-cacciatore
 createdAt: 2025-12-28T19:27:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: chicken
+        quantity: 1
+        note: 'about 1.2–1.5 kg, cut into pieces'
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: onion
+        quantity: 1
+        note: small
+      - id: carrot
+        quantity: 1
+      - id: celery-stalk
+        quantity: 1
+      - id: peeled-tomatoes
+        quantity: 400
+        unit: grams
+        note: 'canned, or rustic passata'
+      - id: red-wine
+        quantity: 1
+        unit: glass
+        note: Chianti or similar
+      - id: rosemary
+        quantity: 1
+        unit: sprig
+      - id: bay-leaves
+        quantity: 2
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
 serves: 4
 status: evergreen
 title: Chicken cacciatore
@@ -13,21 +45,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Chicken (1, about 1.2–1.5 kg, cut into pieces)
-- Garlic cloves (2)
-- Small onion (1)
-- Carrot (1)
-- Celery stalk (1)
-- Canned peeled tomatoes (400 g, or rustic passata)
-- Red wine (1 glass, Chianti or similar)
-- Rosemary (1 sprig)
-- Bay leaves (2)
-- Extra-virgin olive oil (as needed)
-- Salt (to taste)
-- Pepper (to taste)
-
 ## Steps
 
 1. In a wide pan, heat a layer of olive oil and brown the chicken pieces until evenly golden. Remove and set aside.

--- a/src/content/recipes/chicken-curry.mdx
+++ b/src/content/recipes/chicken-curry.mdx
@@ -4,8 +4,57 @@ aliases:
   - chicken-curry
 createdAt: 2025-12-28T19:02:00.000Z
 cuisine: indian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: chicken-thighs
+        quantity: 1.2
+        unit: grams
+        note: 'bone-in, to debone'
+      - id: greek-yogurt
+        quantity: 100
+        unit: grams
+      - id: water
+        note: as needed
+      - id: fresh-cilantro
+        note: as needed
+  - group: Curry spice mix
+    ingredients:
+      - id: ground-turmeric
+        quantity: 10
+        unit: milliliters
+      - id: smoked-paprika
+        quantity: 10
+        unit: milliliters
+      - id: ground-cinnamon
+        quantity: 5
+        unit: milliliters
+      - id: ground-coriander
+        quantity: 5
+        unit: milliliters
+      - id: cayenne-pepper
+        quantity: 5
+        unit: milliliters
+      - id: pepper
+        quantity: 5
+        unit: milliliters
+      - id: salt
+        quantity: 5
+        unit: milliliters
+        note: fine
+  - group: Aromatics
+    ingredients:
+      - id: white-onion
+        quantity: 1
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: fresh-ginger
+        quantity: 20
+        unit: grams
+      - id: fresh-chili
+        quantity: 2
+      - id: extra-virgin-olive-oil
+        note: as needed
 serves: 4
 status: evergreen
 title: Chicken curry
@@ -13,31 +62,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Chicken thighs (1.2 kg, bone-in, to debone)
-- Greek yogurt (100 g)
-- Water (as needed)
-- Fresh cilantro (as needed)
-
-For the curry spice mix:
-
-- Ground turmeric (10 ml)
-- Smoked paprika (10 ml)
-- Ground cinnamon (5 ml)
-- Ground coriander seeds (5 ml)
-- Cayenne pepper (5 ml)
-- Black pepper (5 ml)
-- Fine salt (5 ml)
-
-For the aromatics:
-
-- White onion (1)
-- Garlic cloves (2)
-- Fresh ginger (20 g)
-- Fresh chilies (2)
-- Extra-virgin olive oil (as needed)
-
 ## Steps
 
 1. Debone the chicken thighs and cut into about 3 cm pieces.

--- a/src/content/recipes/chickpea-masala.mdx
+++ b/src/content/recipes/chickpea-masala.mdx
@@ -4,22 +4,24 @@ aliases:
   - chickpea-masala
 createdAt: 2026-01-02T18:21:00.000Z
 cuisine: indian
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: chickpeas
+        quantity: 460
+        unit: grams
+      - 'note: ''[[masala-sauce|Masala sauce]] (1 batch)'''
+      - id: fresh-cilantro
+        note: as needed
+      - id: basmati-rice
+        quantity: 320
+        unit: grams
 serves: 4
 status: evergreen
 title: Chickpea masala
 type: main-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Canned chickpeas (460 g)
-- [[masala-sauce|Masala sauce]] (1 batch)
-- Cilantro (as needed)
-- Basmati rice (320 g)
-
 ## Steps
 
 1. Drain the chickpeas.

--- a/src/content/recipes/chocolate-chip-muffins.mdx
+++ b/src/content/recipes/chocolate-chip-muffins.mdx
@@ -4,8 +4,32 @@ aliases:
   - chocolate-chip-muffins
 createdAt: 2025-12-28T19:17:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: egg
+        quantity: 3
+      - id: granulated-sugar
+        quantity: 180
+        unit: grams
+      - id: milk
+        quantity: 150
+        unit: milliliters
+      - id: butter
+        quantity: 150
+        unit: grams
+      - id: all-purpose-flour
+        quantity: 300
+        unit: grams
+      - id: cocoa-powder
+        quantity: 60
+        unit: grams
+      - id: chocolate-chips
+        quantity: 80
+        unit: grams
+      - id: baking-powder
+        quantity: 16
+        unit: grams
+        note: 1 packet
 serves: 12
 status: evergreen
 title: Chocolate chip muffins
@@ -13,17 +37,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Eggs (3)
-- Sugar (180 g)
-- Milk (150 ml)
-- Butter (150 g)
-- Flour (300 g)
-- Unsweetened cocoa powder (60 g)
-- Chocolate chips (80 g)
-- Baking powder (16 g, 1 packet)
-
 ## Steps
 
 1. Crack the eggs into a bowl and start mixing with an electric whisk.

--- a/src/content/recipes/coleslaw.mdx
+++ b/src/content/recipes/coleslaw.mdx
@@ -4,8 +4,42 @@ aliases:
   - coleslaw
 createdAt: 2025-12-28T19:18:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Salad
+    ingredients:
+      - id: white-cabbage
+        quantity: 500
+        unit: grams
+      - id: carrot
+        quantity: 150
+        unit: grams
+      - id: spring-onion
+        quantity: 1
+  - group: Dressing
+    ingredients:
+      - id: low-fat-yogurt
+        quantity: 300
+        unit: grams
+      - id: mayonnaise
+        quantity: 90
+        unit: milliliters
+      - id: mustard
+        quantity: 30
+        unit: milliliters
+      - id: white-wine-vinegar
+        quantity: 30
+        unit: milliliters
+      - id: granulated-sugar
+        quantity: 30
+        unit: milliliters
+      - id: chives
+        quantity: 60
+        unit: milliliters
+        note: chopped
+      - id: salt
+        note: 'fine, as needed'
+      - id: pepper
+        note: as needed
 serves: 4
 status: evergreen
 title: Coleslaw
@@ -13,25 +47,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the salad:
-
-- White cabbage (500 g)
-- Carrots (150 g)
-- Spring onion (1)
-
-For the dressing:
-
-- Low-fat yogurt (300 g)
-- Mayonnaise (90 ml)
-- Mustard (30 ml)
-- White wine vinegar (30 ml)
-- Sugar (30 ml)
-- Chopped chives (60 ml)
-- Fine salt (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Peel the carrots and cut into julienne (or use pre-cut matchsticks).

--- a/src/content/recipes/creamy-yogurt-cucumber-salad.mdx
+++ b/src/content/recipes/creamy-yogurt-cucumber-salad.mdx
@@ -4,8 +4,37 @@ aliases:
   - creamy-yogurt-cucumber-salad
 createdAt: 2026-03-29T14:59:00.000Z
 cuisine: greek
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Salad
+    ingredients:
+      - id: cucumber
+        quantity: 400
+        unit: grams
+      - id: cherry-tomato
+        quantity: 200
+        unit: grams
+      - id: corn
+        quantity: 120
+        unit: grams
+        note: 'canned, drained'
+      - id: red-onion
+        quantity: 0.5
+  - group: Yogurt dressing
+    ingredients:
+      - id: greek-yogurt
+        quantity: 120
+        unit: grams
+        note: 0% fat
+      - id: extra-virgin-olive-oil
+        quantity: 15
+        unit: milliliters
+      - id: salt
+        quantity: 1
+        unit: pinch
+        note: fine
+      - id: fresh-mint
+        quantity: 5
+        unit: leaves
 serves: 4
 status: evergreen
 title: Creamy yogurt cucumber salad
@@ -13,20 +42,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the salad:
-
-- Cucumbers (400 g)
-- Cherry tomatoes (200 g)
-- Canned sweet corn (120 g, drained)
-- Red onion (½)
-For the yogurt dressing:
-- 0% fat Greek yogurt (120 g)
-- Extra virgin olive oil (15 ml)
-- Fine salt (1 pinch)
-- Fresh mint (5 leaves)
-
 ## Steps
 
 1. Peel the cucumbers and slice them into rounds, thin or thick depending on your preference.

--- a/src/content/recipes/crepes.mdx
+++ b/src/content/recipes/crepes.mdx
@@ -4,8 +4,21 @@ aliases:
   - crepes
 createdAt: 2025-12-28T19:02:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: egg
+        quantity: 3
+        note: Medium
+      - id: 00-flour
+        quantity: 250
+        unit: grams
+      - id: milk
+        quantity: 500
+        unit: grams
+        note: Whole
+      - id: butter
+        quantity: 40
+        unit: grams
 serves: 14
 status: evergreen
 title: Crêpes
@@ -13,13 +26,6 @@ type: other
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Medium eggs (3)
-- 00 flour (250 g)
-- Whole milk (500 g)
-- Butter (40 g)
-
 ## Steps
 
 1. Melt the butter in a small saucepan and let it cool slightly.

--- a/src/content/recipes/crispy-lemon-tofu.mdx
+++ b/src/content/recipes/crispy-lemon-tofu.mdx
@@ -4,8 +4,37 @@ aliases:
   - crispy-lemon-tofu
 createdAt: 2025-12-27T19:41:00.000Z
 cuisine: asian
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: firm-tofu
+        quantity: 250
+        unit: grams
+      - id: soy-sauce
+        quantity: 30
+        unit: milliliters
+      - id: sesame-oil
+        quantity: 5
+        unit: milliliters
+        note: optional
+      - id: lemon-juice
+        quantity: 1
+        unit: organic lemon
+      - id: lemon-zest
+        quantity: 1
+        unit: organic lemon
+        note: grated
+      - id: cornstarch
+        quantity: 30
+        unit: milliliters
+      - id: breadcrumbs
+        quantity: 45
+        unit: milliliters
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: to taste
 serves: 2
 status: budding
 title: Crispy lemon tofu
@@ -13,19 +42,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Firm tofu (250 g)
-- Soy sauce (30 ml)
-- Sesame oil (5 ml, optional)
-- Lemon juice (1 organic lemon)
-- Lemon zest (1 organic lemon, grated)
-- Cornflour (30 ml)
-- Breadcrumbs (45 ml)
-- Salt (to taste)
-- Pepper (to taste)
-- Extra-virgin olive oil (to taste)
-
 ## Steps
 
 1. Pat the tofu dry with paper towels, then cut into sticks about 1 cm thick.

--- a/src/content/recipes/farro-with-tuna-olives-and-cherry-tomatoes.mdx
+++ b/src/content/recipes/farro-with-tuna-olives-and-cherry-tomatoes.mdx
@@ -4,27 +4,40 @@ aliases:
   - farro-with-tuna-olives-and-cherry-tomatoes
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pearled-farro
+        quantity: 160
+        unit: grams
+      - id: canned-tuna-in-oil
+        quantity: 160
+        unit: grams
+        note: 'drained, good-quality'
+      - id: cherry-tomato
+        quantity: 200
+        unit: grams
+        note: datterini or cherry
+      - id: taggiasca-olives
+        quantity: 40
+        unit: grams
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
+      - id: fresh-basil
+        note: a few
 serves: 2
 status: evergreen
 title: 'Farro with tuna, olives, and cherry tomatoes'
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pearled farro (160 g)
-- Good-quality canned tuna in oil (160 g, drained)
-- Cherry tomatoes (200 g, datterini or cherry)
-- Pitted Taggiasca olives (40 g)
-- Garlic (1 clove)
-- Extra-virgin olive oil (to taste)
-- Salt (to taste)
-- Pepper (to taste)
-- Fresh basil leaves (a few)
-
 ## Steps
 
 1. Rinse the farro under running water, then boil it in plenty of salted water for 20–25 minutes (check the package time).

--- a/src/content/recipes/fusilli-with-gilthead-bream-ragu.mdx
+++ b/src/content/recipes/fusilli-with-gilthead-bream-ragu.mdx
@@ -4,8 +4,45 @@ aliases:
   - fusilli-with-gilthead-bream-ragu
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 160
+        unit: grams
+        note: 'mezze maniche, paccheri, or tagliolini'
+      - id: gilthead-bream-fillet
+        quantity: 400
+        unit: grams
+      - id: cherry-tomato
+        quantity: 15
+      - id: dry-white-wine
+        quantity: 100
+        unit: milliliters
+      - id: tomato-passata
+        quantity: 30
+        unit: milliliters
+      - id: pistachio
+        note: 'chopped, as needed'
+      - id: fresh-basil
+        quantity: 2
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+  - group: Classic soffritto (option 1)
+    ingredients:
+      - id: celery-stalk
+        quantity: 1
+      - id: shallot
+        quantity: 1
+  - group: Pre-made soffritto (option 2)
+    ingredients:
+      - id: soffritto-mix
+        quantity: 30
+        unit: milliliters
+        note: 'frozen, 30–45 ml'
 serves: 2
 status: evergreen
 title: Fusilli with gilthead bream ragù
@@ -13,24 +50,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pasta (160 g, mezze maniche, paccheri, or tagliolini)
-- Gilthead bream fillets (400 g)
-- Pachino cherry tomatoes (15)
-- White wine (100 ml)
-- Tomato passata (30 ml)
-- Chopped pistachios (as needed)
-- Basil leaves (2)
-- Extra-virgin olive oil (to taste)
-- Salt (as needed)
-- Pepper (as needed)
-For the classic soffritto (option 1):
-- Celery (1 stalk)
-- Shallot (1)
-For the pre-made soffritto (option 2):
-- Frozen soffritto mix (30–45 ml)
-
 ## Steps
 
 1. Bring a pot of salted water to a boil for the pasta.

--- a/src/content/recipes/fusilli-with-tuna-and-zucchini.mdx
+++ b/src/content/recipes/fusilli-with-tuna-and-zucchini.mdx
@@ -4,8 +4,28 @@ aliases:
   - fusilli-with-tuna-and-zucchini
 createdAt: 2026-01-03T12:52:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+      - id: zucchini
+        quantity: 2
+      - id: onion
+        quantity: 0.5
+      - id: canned-tuna-in-oil
+        quantity: 200
+        unit: grams
+        note: drained
+      - id: dry-white-wine
+        quantity: 100
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: salt
+        note: 'fine, to taste'
+      - id: parsley
+        note: 'chopped, to taste'
 serves: 4
 status: evergreen
 title: Fusilli with tuna and zucchini
@@ -13,17 +33,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Fusilli (320 g)
-- Zucchini (2)
-- Onion (½)
-- Canned tuna (200 g, drained)
-- White wine (100 ml)
-- Extra-virgin olive oil (to taste)
-- Fine salt (to taste)
-- Chopped parsley (to taste)
-
 ## Steps
 
 1. Cook the pasta in a pot of boiling salted water.

--- a/src/content/recipes/gricia.mdx
+++ b/src/content/recipes/gricia.mdx
@@ -4,20 +4,21 @@ aliases:
   - gricia
 createdAt: 2025-12-28T19:03:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - >-
+        note: 'Ingredients for [[spaghetti-cacio-e-pepe|Spaghetti cacio e
+        pepe]]'
+      - id: guanciale
+        quantity: 50
+        unit: grams
 serves: 2
 status: evergreen
 title: Gricia
 type: first-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ingredients for [[spaghetti-cacio-e-pepe|Spaghetti cacio e pepe]]
-- Guanciale (50 g)
-
 ## Steps
 
 1. Cut the guanciale into strips.

--- a/src/content/recipes/gyoza.mdx
+++ b/src/content/recipes/gyoza.mdx
@@ -4,8 +4,55 @@ aliases:
   - gyoza
 createdAt: 2025-12-28T19:00:00.000Z
 cuisine: asian
-diets:
-  - vegan
+ingredient_groups:
+  - group: Wrappers
+    ingredients:
+      - id: 00-flour
+        quantity: 250
+        unit: grams
+      - id: water
+        quantity: 200
+        unit: grams
+        note: boiling
+      - id: potato-starch
+        note: 'as needed, for rolling'
+  - group: Filling
+    ingredients:
+      - id: ground-pork
+        quantity: 200
+        unit: grams
+      - id: white-cabbage
+        quantity: 120
+        unit: grams
+      - id: spring-onion
+        quantity: 1
+      - id: fresh-ginger
+        note: 'as needed, grated'
+      - id: garlic
+        note: 'optional, grated'
+      - id: soy-sauce
+        quantity: 10
+        unit: grams
+      - id: sake
+        quantity: 10
+        unit: grams
+      - id: toasted-sesame-oil
+        quantity: 10
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+  - group: Dipping sauce
+    ingredients:
+      - id: soy-sauce
+        quantity: 50
+        unit: grams
+      - id: rice-vinegar
+        quantity: 40
+        unit: grams
+      - id: rayu-chili-oil
+        note: as needed
 serves: 30
 status: evergreen
 title: Gyoza
@@ -13,29 +60,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the wrappers:
-
-- 00 flour (250 g)
-- Boiling water (200 g)
-- Potato starch (as needed, for rolling)
-For the filling:
-- Ground pork (200 g)
-- White cabbage (120 g)
-- Spring onion (1)
-- Fresh ginger (as needed, grated)
-- Garlic (optional, grated)
-- Soy sauce (10 g)
-- Sake (10 g)
-- Toasted sesame oil (10 g)
-- Salt (as needed)
-- Black pepper (as needed)
-For the dipping sauce:
-- Soy sauce (50 g)
-- Rice vinegar (40 g)
-- Rayu chili oil (as needed)
-
 ## Steps
 
 1. Pour the boiling water over the flour.

--- a/src/content/recipes/hasselback-potatoes.mdx
+++ b/src/content/recipes/hasselback-potatoes.mdx
@@ -4,8 +4,34 @@ aliases:
   - hasselback-potatoes
 createdAt: 2026-03-28T11:20:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 1500
+        unit: grams
+      - id: grana-padano
+        quantity: 150
+        unit: grams
+        note: to grate
+      - id: rosemary
+        quantity: 1
+        unit: sprig
+      - id: thyme
+        quantity: 4
+        unit: sprigs
+      - id: oregano
+        quantity: 4
+        unit: sprigs
+      - id: extra-virgin-olive-oil
+        quantity: 50
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
 serves: 4
 status: seedling
 title: Hasselback potatoes
@@ -13,18 +39,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Potatoes (1500 g)
-- Grana Padano DOP (150 g, to grate)
-- Rosemary (1 sprig)
-- Thyme (4 sprigs)
-- Oregano (4 sprigs)
-- Extra-virgin olive oil (50 ml)
-- Garlic (1 clove)
-- Fine salt (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Wash the potatoes well under running water.

--- a/src/content/recipes/jacket-potatoes.mdx
+++ b/src/content/recipes/jacket-potatoes.mdx
@@ -4,8 +4,10 @@ aliases:
   - jacket-potatoes
 createdAt: 2026-04-11T08:57:00.000Z
 cuisine: british
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 8
 serves: 4
 status: evergreen
 title: Jacket potatoes
@@ -13,10 +15,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Medium-large potatoes (8)
-
 ## Steps
 
 1. Wash the potatoes under running water, scrubbing them well to remove any dirt.

--- a/src/content/recipes/king-prawn-spaghetti.mdx
+++ b/src/content/recipes/king-prawn-spaghetti.mdx
@@ -4,8 +4,59 @@ aliases:
   - king-prawn-spaghetti
 createdAt: 2026-05-23T16:56:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+      - id: king-prawns
+        quantity: 900
+        unit: grams
+        note: shell-on
+      - id: cherry-tomato
+        quantity: 180
+        unit: grams
+      - id: dry-white-wine
+        quantity: 50
+        unit: grams
+      - id: garlic
+        quantity: 1
+        unit: clove
+        note: unpeeled
+      - id: lemon
+        quantity: 1
+      - id: fresh-chili
+        note: to taste
+      - id: parsley
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: salt
+        note: to taste
+      - id: white-pepper
+        note: to taste
+  - group: Bisque
+    ingredients:
+      - id: water
+        quantity: 1000
+        unit: milliliters
+      - id: shallot
+        quantity: 2
+      - id: dry-white-wine
+        quantity: 50
+        unit: grams
+      - id: white-peppercorns
+        note: to taste
+      - id: cherry-tomato
+        quantity: 100
+        unit: grams
+      - id: parsley
+        quantity: 1
+        unit: sprig
+      - id: black-peppercorns
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: to taste
 serves: 4
 status: evergreen
 title: King prawn spaghetti
@@ -13,29 +64,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti (320 g)
-- King prawns (900 g, shell-on)
-- Cherry tomatoes (180 g)
-- Dry white wine (50 g)
-- Garlic (1 clove, unpeeled)
-- Lemon (1)
-- Chili pepper (to taste)
-- Fresh parsley (to taste)
-- Extra virgin olive oil (to taste)
-- Fine salt (to taste)
-- White pepper (to taste)
-For the bisque:
-- Water (1 lt)
-- Shallots (2)
-- Dry white wine (50 g)
-- White peppercorns (to taste)
-- Cherry tomatoes (100 g)
-- Fresh parsley (1 sprig)
-- Black peppercorns (to taste)
-- Extra virgin olive oil (to taste)
-
 ## Steps
 
 1. Clean the king prawns: remove the heads, legs, and shells.

--- a/src/content/recipes/leek-and-potato-soup.mdx
+++ b/src/content/recipes/leek-and-potato-soup.mdx
@@ -4,8 +4,21 @@ aliases:
   - leek-and-potato-soup
 createdAt: 2025-12-28T18:57:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: leek
+        quantity: 8
+      - id: potato
+        quantity: 8
+      - id: soy-yogurt
+        quantity: 60
+        unit: milliliters
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+      - id: olive-oil
+        note: as needed
 serves: 4
 status: evergreen
 title: Leek and potato soup
@@ -13,15 +26,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Leeks (8)
-- Medium potatoes (8)
-- Soy yogurt (60 ml)
-- Salt (as needed)
-- Pepper (as needed)
-- Olive oil (as needed)
-
 ## Steps
 
 1. Slice the leeks, peel and dice the potatoes, then sauté everything in a pan for 5 minutes with a drizzle of olive oil.

--- a/src/content/recipes/lentil-meatballs.mdx
+++ b/src/content/recipes/lentil-meatballs.mdx
@@ -4,8 +4,47 @@ aliases:
   - lentil-meatballs
 createdAt: 2025-12-28T18:59:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - group: Meatballs
+    ingredients:
+      - id: lentils
+        quantity: 600
+        unit: grams
+      - id: sun-dried-tomatoes
+        quantity: 10
+      - id: golden-onion
+        quantity: 1
+      - id: soy-sauce
+        quantity: 30
+        unit: milliliters
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: extra-virgin-olive-oil
+        quantity: 60
+        unit: milliliters
+      - id: breadcrumbs
+        note: as needed
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
+      - id: thyme
+        quantity: 10
+        unit: milliliters
+  - group: Tomato sauce
+    ingredients:
+      - id: tomato-passata
+        quantity: 1400
+        unit: grams
+      - id: golden-onion
+        quantity: 1
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: fresh-basil
+        note: as needed
+      - id: salt
+        note: to taste
 serves: 4
 status: evergreen
 title: Lentil meatballs
@@ -13,27 +52,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the meatballs:
-
-- Cooked lentils (600 g)
-- Sun-dried tomatoes (10)
-- Golden onion (1)
-- Soy sauce (30 ml)
-- Garlic cloves (2)
-- Extra-virgin olive oil (60 ml)
-- Breadcrumbs (as needed)
-- Salt (to taste)
-- Pepper (to taste)
-- Thyme (10 ml)
-For the tomato sauce:
-- Tomato passata (1400 g)
-- Golden onion (1)
-- Extra-virgin olive oil (as needed)
-- Basil (as needed)
-- Salt (to taste)
-
 ## Steps
 
 1. Preheat the oven to 220 °C (static).

--- a/src/content/recipes/masala-sauce.mdx
+++ b/src/content/recipes/masala-sauce.mdx
@@ -4,8 +4,44 @@ aliases:
   - masala-sauce
 createdAt: 2026-01-02T19:10:00.000Z
 cuisine: indian
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: peeled-tomatoes
+        quantity: 250
+        unit: grams
+      - id: coconut-milk
+        quantity: 200
+        unit: milliliters
+      - id: golden-onion
+        quantity: 0.5
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: fresh-chili
+        quantity: 1
+      - id: fresh-ginger
+        note: as needed
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: ground-cumin
+        quantity: 5
+        unit: milliliters
+      - id: sweet-paprika
+        quantity: 5
+        unit: milliliters
+        note: mild
+      - id: ground-garam-masala
+        quantity: 5
+        unit: milliliters
+      - id: mild-curry-powder
+        quantity: 15
+        unit: milliliters
+      - id: salt
+        note: as needed
+      - id: fresh-cilantro
+        note: as needed
+      - id: lime-juice
+        note: as needed
 serves: 4
 status: evergreen
 title: Masala sauce
@@ -13,23 +49,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Canned peeled tomatoes (250 g)
-- Coconut milk (200 ml)
-- Golden onion (½)
-- Garlic (1 clove)
-- Chili pepper (1)
-- Fresh ginger (as needed)
-- Extra-virgin olive oil (as needed)
-- Ground cumin (5 ml)
-- Paprika (5 ml)
-- Garam masala (5 ml)
-- Mild curry powder (15 ml)
-- Salt (as needed)
-- Cilantro (as needed)
-- Lime juice (as needed)
-
 ## Steps
 
 1. Finely chop the onion, garlic, ginger, and chili.

--- a/src/content/recipes/miso-chicken-vermicelli-bowl.mdx
+++ b/src/content/recipes/miso-chicken-vermicelli-bowl.mdx
@@ -4,8 +4,37 @@ aliases:
   - miso-chicken-vermicelli-bowl
 createdAt: 2025-12-28T19:13:00.000Z
 cuisine: asian
-diets:
-  - omnivore
+ingredient_groups:
+  - group: Chicken and marinade
+    ingredients:
+      - id: chicken-breast
+        note: 300–350 g
+      - id: red-miso-paste
+        quantity: 15
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        quantity: 15
+        unit: milliliters
+      - id: honey
+        quantity: 15
+        unit: milliliters
+      - id: garlic-ginger-paste
+        quantity: 5
+        unit: milliliters
+  - group: Vermicelli
+    ingredients:
+      - id: dried-rice-vermicelli
+        note: 120–160 g
+  - group: Vegetables and toppings
+    ingredients:
+      - id: carrot
+        note: as needed
+      - id: cucumber
+        note: as needed
+      - id: red-cabbage
+        note: 'as needed, or savoy cabbage'
+      - id: cashews
+        note: as needed
 serves: 2
 status: evergreen
 title: Miso chicken vermicelli bowl
@@ -13,23 +42,6 @@ type: single-dish
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the chicken and marinade:
-
-- Chicken breast (300–350 g)
-- Red miso paste (30 ml)
-- Extra-virgin olive oil (15 ml)
-- Honey (15 ml)
-- Garlic or ginger paste (5 ml)
-For the vermicelli:
-- Dried rice vermicelli (120–160 g)
-For the vegetables and toppings:
-- Carrots (as needed)
-- Cucumber (as needed)
-- Red cabbage or savoy cabbage (as needed)
-- Cashews (as needed)
-
 ## Steps
 
 1. Cut the chicken breast into thin strips.

--- a/src/content/recipes/mixed-berry-cheesecake.mdx
+++ b/src/content/recipes/mixed-berry-cheesecake.mdx
@@ -4,41 +4,77 @@ aliases:
   - mixed-berry-cheesecake
 createdAt: 2026-04-04T10:41:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Base (20 cm tin)
+    ingredients:
+      - id: digestive-biscuits
+        quantity: 180
+        unit: grams
+      - id: butter
+        quantity: 100
+        unit: grams
+  - group: Cream
+    ingredients:
+      - id: cow-ricotta
+        quantity: 500
+        unit: grams
+      - id: cream-cheese
+        quantity: 250
+        unit: grams
+      - id: fresh-liquid-cream
+        quantity: 100
+        unit: grams
+      - id: powdered-sugar
+        quantity: 150
+        unit: grams
+      - id: sheet-gelatin
+        quantity: 10
+        unit: grams
+      - id: lemon-zest
+        quantity: 1
+        unit: lemon
+        note: grated
+  - group: Filling
+    ingredients:
+      - id: blackberries
+        quantity: 190
+        unit: grams
+      - id: blueberries
+        quantity: 180
+        unit: grams
+      - id: raspberries
+        quantity: 180
+        unit: grams
+      - id: redcurrants
+        quantity: 135
+        unit: grams
+      - id: powdered-sugar
+        quantity: 100
+        unit: grams
+      - id: lemon-juice
+        quantity: 70
+        unit: grams
+  - group: Topping
+    ingredients:
+      - id: cornstarch
+        quantity: 35
+        unit: grams
+      - id: mixed-berries
+        quantity: 280
+        unit: grams
+  - group: Garnish
+    ingredients:
+      - id: mixed-berries
+        quantity: 50
+        unit: grams
+      - id: fresh-mint
+        note: to taste
 status: budding
 title: Mixed berry cheesecake
 type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the base (20 cm tin):
-
-- Digestive biscuits (180 g)
-- Butter (100 g)
-For the cream:
-- Cow ricotta (500 g)
-- Cream cheese (250 g)
-- Fresh liquid cream (100 g)
-- Powdered sugar (150 g)
-- Sheet gelatin (10 g)
-- Lemon zest (1 lemon, grated)
-For the filling:
-- Blackberries (190 g)
-- Blueberries (180 g)
-- Raspberries (180 g)
-- Redcurrants (135 g)
-- Powdered sugar (100 g)
-- Lemon juice (70 g)
-For the topping:
-- Cornstarch (35 g)
-- Mixed berries (280 g)
-For garnish:
-- Mixed berries (50 g)
-- Mint (to taste)
-
 ## Steps
 
 1. Melt the butter over low heat and let it cool slightly.

--- a/src/content/recipes/molten-chocolate-cake.mdx
+++ b/src/content/recipes/molten-chocolate-cake.mdx
@@ -4,8 +4,33 @@ aliases:
   - molten-chocolate-cake
 createdAt: 2026-03-28T11:20:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - group: Chocolate cakes
+    ingredients:
+      - id: dark-chocolate
+        quantity: 200
+        unit: grams
+      - id: butter
+        quantity: 100
+        unit: grams
+        note: plus extra to grease the molds
+      - id: granulated-sugar
+        quantity: 120
+        unit: grams
+      - id: egg
+        quantity: 3
+      - id: all-purpose-flour
+        quantity: 50
+        unit: grams
+      - id: vanilla-extract
+        quantity: 5
+        unit: milliliters
+      - id: cocoa-powder
+        note: 'as needed, also to dust the molds and the surface'
+  - group: To finish
+    ingredients:
+      - id: powdered-sugar
+        note: as needed
 serves: 6
 status: seedling
 title: Molten chocolate cake
@@ -13,20 +38,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the chocolate cakes:
-
-- Dark chocolate (200 g)
-- Butter (100 g, plus extra to grease the molds)
-- Sugar (120 g)
-- Eggs (3)
-- Flour (50 g)
-- Vanilla extract (5 ml)
-- Unsweetened cocoa powder (as needed, also to dust the molds and the surface)
-To finish:
-- Powdered sugar (as needed)
-
 ## Steps
 
 1. In a bowl, combine the melted dark chocolate and the melted butter. Whisk until smooth.

--- a/src/content/recipes/mushroom-veal-scaloppine.mdx
+++ b/src/content/recipes/mushroom-veal-scaloppine.mdx
@@ -4,8 +4,32 @@ aliases:
   - mushroom-veal-scaloppine
 createdAt: 2026-03-29T14:56:00.000Z
 cuisine: italian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: veal-escalopes
+        quantity: 400
+        unit: grams
+        note: thinly sliced
+      - id: champignon-mushrooms
+        quantity: 500
+        unit: grams
+      - id: butter
+        quantity: 100
+        unit: grams
+        note: divided into two 50 g portions
+      - id: dry-white-wine
+        quantity: 40
+        unit: grams
+      - id: all-purpose-flour
+        quantity: 40
+        unit: grams
+        note: for dredging
+      - id: parsley
+        note: to taste
+      - id: salt
+        note: 'to taste, fine'
+      - id: black-peppercorns
+        note: to taste
 serves: 4
 status: evergreen
 title: Mushroom veal scaloppine
@@ -13,17 +37,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Veal escalopes (400 g, thinly sliced)
-- Champignon mushrooms (500 g)
-- Butter (100 g, divided into two 50 g portions)
-- Dry white wine (40 g)
-- All-purpose flour (40 g, for dredging)
-- Fresh parsley (to taste)
-- Fine salt (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. Using a small sharp knife, trim the earthy base of each mushroom stem and gently scrape away any remaining dirt.

--- a/src/content/recipes/naan.mdx
+++ b/src/content/recipes/naan.mdx
@@ -4,8 +4,24 @@ aliases:
   - naan
 createdAt: 2025-12-27T19:41:00.000Z
 cuisine: indian
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: 00-flour
+        quantity: 500
+        unit: grams
+      - id: plain-yogurt
+        quantity: 250
+        unit: grams
+      - id: water
+        quantity: 100
+        unit: grams
+      - id: salt
+        quantity: 7
+        unit: grams
+        note: fine
+      - id: fresh-bakers-yeast
+        quantity: 2
+        unit: grams
 serves: 8
 status: budding
 title: Naan
@@ -13,14 +29,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- 00 flour (500 g)
-- Plain yogurt (250 g)
-- Water (100 g)
-- Fine salt (7 g)
-- Fresh baker’s yeast (2 g)
-
 ## Steps
 
 1. Put the flour in a bowl.

--- a/src/content/recipes/nutella-cheesecake.mdx
+++ b/src/content/recipes/nutella-cheesecake.mdx
@@ -4,8 +4,25 @@ aliases:
   - nutella-cheesecake
 createdAt: 2026-04-04T10:45:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: digestive-biscuits
+        quantity: 270
+        unit: grams
+      - id: butter
+        quantity: 120
+        unit: grams
+      - id: nutella
+        quantity: 500
+        unit: grams
+      - id: cream-cheese
+        quantity: 500
+        unit: grams
+        note: Philadelphia brand
+      - id: hazelnuts
+        quantity: 30
+        unit: grams
+        note: chopped
 serves: 6
 status: budding
 title: Nutella cheesecake
@@ -13,14 +30,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Digestive biscuits (270 g)
-- Butter (120 g)
-- Nutella (500 g)
-- Philadelphia cream cheese (500 g)
-- Chopped hazelnuts (30 g)
-
 ## Steps
 
 1. Melt the butter in a small saucepan over very low heat, then let cool slightly.

--- a/src/content/recipes/oven-roasted-potatoes.mdx
+++ b/src/content/recipes/oven-roasted-potatoes.mdx
@@ -4,8 +4,19 @@ aliases:
   - oven-roasted-potatoes
 createdAt: 2025-12-28T19:29:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 1000
+        unit: grams
+      - id: olive-oil
+        note: as needed
+      - id: clarified-butter
+        note: as needed
+      - id: rosemary
+        note: as needed
+      - id: salt
+        note: as needed
 serves: 2
 status: evergreen
 title: Oven-roasted potatoes
@@ -13,14 +24,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Potatoes (1 kg)
-- Olive oil (as needed)
-- Clarified butter (as needed)
-- Rosemary (as needed)
-- Salt (as needed)
-
 ## Steps
 
 1. Bring a pot of water to a boil.

--- a/src/content/recipes/panko-beef-cutlets.mdx
+++ b/src/content/recipes/panko-beef-cutlets.mdx
@@ -4,8 +4,23 @@ aliases:
   - panko-beef-cutlets
 createdAt: 2026-01-03T12:35:00.000Z
 cuisine: italian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: beef-topside
+        quantity: 600
+        unit: grams
+        note: 4 slices of 150 g each
+      - id: all-purpose-flour
+        note: as needed
+      - id: panko
+        note: as needed
+      - id: egg
+        quantity: 2
+      - id: clarified-butter
+        quantity: 250
+        unit: grams
+      - id: salt
+        note: 'fine, as needed'
 serves: 4
 status: evergreen
 title: Panko beef cutlets
@@ -13,15 +28,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Beef topside (600 g, 4 slices of 150 g each)
-- Flour (as needed)
-- Panko (as needed)
-- Eggs (2)
-- Clarified butter (250 g)
-- Fine salt (as needed)
-
 ## Steps
 
 1. If the beef slices are too thick, pound them gently to make them thinner.

--- a/src/content/recipes/paprika-kale-chips.mdx
+++ b/src/content/recipes/paprika-kale-chips.mdx
@@ -4,8 +4,18 @@ aliases:
   - paprika-kale-chips
 createdAt: 2025-12-28T19:17:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: tuscan-kale
+        quantity: 4
+      - id: sweet-paprika
+        note: as needed
+      - id: garlic-powder
+        note: as needed
+      - id: salt
+        note: to taste
+      - id: olive-oil
+        note: as needed
 serves: 4
 status: evergreen
 title: Paprika kale chips
@@ -13,14 +23,6 @@ type: side
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Tuscan kale leaves (4)
-- Paprika (as needed)
-- Garlic powder (as needed)
-- Salt (to taste)
-- Olive oil (as needed)
-
 ## Steps
 
 1. Remove the tough ribs from the kale leaves and tear into pieces.

--- a/src/content/recipes/pasta-and-chickpeas.mdx
+++ b/src/content/recipes/pasta-and-chickpeas.mdx
@@ -4,8 +4,33 @@ aliases:
   - pasta-and-chickpeas
 createdAt: 2025-12-28T19:27:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: chickpeas
+        quantity: 350
+        unit: grams
+        note: cooked
+      - id: pasta
+        quantity: 160
+        unit: grams
+        note: 'of your choice, preferably small or short'
+      - id: anchovy-fillets
+        note: '5–6, omnivores only'
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: rosemary
+        unit: sprig
+        note: a few
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+      - id: water
+        quantity: 500
+        unit: milliliters
 serves: 2
 status: evergreen
 title: Pasta and chickpeas
@@ -13,18 +38,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Cooked chickpeas (350 g)
-- Pasta of your choice, preferably small or short (160 g)
-- Anchovy fillets (5–6, omnivores only)
-- Garlic cloves (2)
-- Rosemary sprigs (a few)
-- Extra-virgin olive oil (as needed)
-- Salt (as needed)
-- Pepper (as needed)
-- Water (500 ml)
-
 ## Steps
 
 1. Rinse the chickpeas and optionally remove the skins.

--- a/src/content/recipes/pasta-with-nduja-and-cherry-tomatoes.mdx
+++ b/src/content/recipes/pasta-with-nduja-and-cherry-tomatoes.mdx
@@ -4,8 +4,27 @@ aliases:
   - pasta-with-nduja-and-cherry-tomatoes
 createdAt: 2025-12-28T19:28:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 200
+        unit: grams
+      - id: cherry-tomato
+        quantity: 150
+        unit: grams
+      - id: nduja
+        quantity: 50
+        unit: grams
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        quantity: 30
+        unit: milliliters
+      - id: salt
+        note: as needed
+      - id: fresh-basil
+        note: as needed
 serves: 2
 status: evergreen
 title: Pasta with ’nduja and cherry tomatoes
@@ -13,16 +32,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pasta (200 g)
-- Cherry tomatoes (150 g)
-- ‘Nduja (50 g)
-- Garlic clove (1)
-- Extra-virgin olive oil (30 ml)
-- Salt (as needed)
-- Basil (as needed)
-
 ## Steps
 
 1. Bring a pot of salted water to a boil.

--- a/src/content/recipes/patatas-bravas.mdx
+++ b/src/content/recipes/patatas-bravas.mdx
@@ -4,8 +4,40 @@ aliases:
   - patatas-bravas
 createdAt: 2025-12-27T19:25:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - group: Potatoes
+    ingredients:
+      - id: potato
+        quantity: 4
+      - id: vegetable-oil
+        note: as needed
+      - id: salt
+        note: as needed
+  - group: Brava sauce
+    ingredients:
+      - id: onion
+        quantity: 1
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: olive-oil
+        note: as needed
+      - id: water
+        quantity: 240
+        unit: milliliters
+      - id: apple-cider-vinegar
+        quantity: 30
+        unit: milliliters
+      - id: smoked-paprika
+        quantity: 15
+        unit: milliliters
+      - id: all-purpose-flour
+        quantity: 15
+        unit: milliliters
+  - group: To serve
+    ingredients:
+      - id: chives
+        note: as needed
 serves: 4
 status: budding
 title: Patatas bravas
@@ -13,28 +45,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the potatoes:
-
-- Potatoes (4)
-- Frying oil (as needed)
-- Fine salt (as needed)
-
-For the brava sauce:
-
-- Medium onion (1)
-- Garlic clove (1)
-- Olive oil (as needed)
-- Water (240 ml)
-- Apple cider vinegar (30 ml)
-- Smoked paprika (15 ml)
-- Flour (15 ml)
-
-To serve:
-
-- Chives (as needed)
-
 ## Steps
 
 1. Finely chop the onion.

--- a/src/content/recipes/peanut-butter-and-banana-toast.mdx
+++ b/src/content/recipes/peanut-butter-and-banana-toast.mdx
@@ -4,8 +4,21 @@ aliases:
   - peanut-butter-and-banana-toast
 createdAt: 2026-01-03T12:49:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: whole-wheat-bread
+        quantity: 50
+        unit: grams
+        note: 1 slice
+      - id: peanut-butter
+        quantity: 15
+        unit: milliliters
+      - id: banana
+        quantity: 1
+      - id: dark-chocolate
+        quantity: 20
+        unit: grams
+        note: 85% cocoa
 serves: 1
 status: evergreen
 title: Peanut butter and banana toast
@@ -13,13 +26,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Whole wheat bread (50 g, 1 slice)
-- Peanut butter (15 ml)
-- Banana (1)
-- Dark chocolate 85% cocoa (20 g)
-
 ## Steps
 
 1. Toast the bread.

--- a/src/content/recipes/penne-al-baffo.mdx
+++ b/src/content/recipes/penne-al-baffo.mdx
@@ -4,8 +4,30 @@ aliases:
   - penne-al-baffo
 createdAt: 2025-12-28T19:05:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+        note: preferably mezze penne rigate
+      - id: cooked-ham
+        quantity: 100
+        unit: grams
+        note: sliced
+      - id: heavy-cream
+        quantity: 300
+        unit: grams
+      - id: tomato-passata
+        quantity: 25
+        unit: grams
+      - id: parsley
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
 serves: 4
 status: evergreen
 title: Penne al baffo
@@ -13,17 +35,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Penne, preferably mezze penne rigate (320 g)
-- Cooked ham (100 g, sliced)
-- Fresh heavy cream (300 g)
-- Tomato passata (25 g)
-- Parsley (as needed)
-- Fine salt (as needed)
-- Extra-virgin olive oil (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Wash, dry, and finely chop the parsley. Set aside.

--- a/src/content/recipes/pesto-alla-genovese.mdx
+++ b/src/content/recipes/pesto-alla-genovese.mdx
@@ -4,24 +4,35 @@ aliases:
   - pesto-alla-genovese
 createdAt: 2025-11-02T14:05:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: fresh-basil
+        quantity: 70
+        unit: grams
+      - id: extra-virgin-olive-oil
+        quantity: 70
+        unit: grams
+      - id: parmigiano-reggiano
+        quantity: 50
+        unit: grams
+      - id: pecorino-sardo
+        quantity: 30
+        unit: grams
+      - id: pine-nuts
+        quantity: 30
+        unit: grams
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: sea-salt
+        quantity: 3
+        unit: grams
 status: seedling
 title: Pesto alla genovese
 type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Basil (70 g)
-- Extra virgin olive oil (70 g)
-- Parmigiano Reggiano (50 g)
-- Sardinian pecorino (30 g)
-- Pine nuts (30 g)
-- Garlic cloves (2)
-- Coarse sea salt (3 g)
-
 ## Steps
 
 1. Pull the basil leaves from the stems, rinse them quickly under cold water, and dry them gently on a tea towel.

--- a/src/content/recipes/pinsa-with-burrata-mortadella-and-pistachios.mdx
+++ b/src/content/recipes/pinsa-with-burrata-mortadella-and-pistachios.mdx
@@ -4,24 +4,33 @@ aliases:
   - pinsa-with-burrata-mortadella-and-pistachios
 createdAt: 2025-12-28T19:12:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pinsa-romana-base
+        quantity: 2
+        note: Ready-made
+      - id: burrata
+        quantity: 1
+        note: 200 g
+      - id: mortadella
+        quantity: 150
+        unit: grams
+        note: 'Good-quality, thinly sliced'
+      - id: pistachio
+        quantity: 40
+        unit: grams
+        note: 'Toasted, chopped'
+      - id: extra-virgin-olive-oil
+        note: 'As needed, mild'
+      - id: black-peppercorns
+        note: 'Freshly ground, to taste'
 serves: 2
 status: evergreen
 title: 'Pinsa with burrata, mortadella, and pistachios'
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ready-made pinsa romana bases (2)
-- Burrata (1, 200 g)
-- Good-quality mortadella, thinly sliced (150 g)
-- Toasted chopped pistachios (40 g)
-- Mild extra-virgin olive oil (as needed)
-- Freshly ground black pepper (to taste)
-
 ## Steps
 
 1. Bake the pinsa bases at 220 °C for 5-6 minutes, until crisp and golden.

--- a/src/content/recipes/pinsa-with-smoked-salmon-burrata-lamb-s-lettuce-lemon-and-balsamic-glaze.mdx
+++ b/src/content/recipes/pinsa-with-smoked-salmon-burrata-lamb-s-lettuce-lemon-and-balsamic-glaze.mdx
@@ -4,27 +4,38 @@ aliases:
   - pinsa-with-smoked-salmon-burrata-lamb-s-lettuce-lemon-and-balsamic-glaze
 createdAt: 2025-12-28T19:12:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pinsa-romana-base
+        quantity: 2
+        note: ready-made
+      - id: smoked-salmon
+        quantity: 150
+        unit: grams
+      - id: burrata
+        quantity: 200
+        unit: grams
+      - id: lambs-lettuce
+        quantity: 50
+        unit: grams
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: lemon
+        quantity: 0.5
+        note: juice and zest
+      - id: balsamic-glaze
+        note: as needed
+      - id: salt
+        note: to taste
+      - id: black-peppercorns
+        note: 'freshly ground, to taste'
 serves: 2
 status: evergreen
 title: 'Pinsa with smoked salmon, burrata, lamb’s lettuce, lemon, and balsamic glaze'
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ready-made pinsa romana bases (2)
-- Smoked salmon (150 g)
-- Burrata (1, 200 g)
-- Lamb’s lettuce (50 g)
-- Extra-virgin olive oil (as needed)
-- Unwaxed lemon (½, juice and zest)
-- Balsamic glaze (as needed)
-- Salt (to taste)
-- Freshly ground black pepper (to taste)
-
 ## Steps
 
 1. Heat the pinsa bases in a preheated oven at 220 °C for 5–6 minutes, until crisp outside and soft inside.

--- a/src/content/recipes/pistachio-crusted-salmon.mdx
+++ b/src/content/recipes/pistachio-crusted-salmon.mdx
@@ -4,8 +4,28 @@ aliases:
   - pistachio-crusted-salmon
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: salmon-fillet
+        quantity: 2
+      - id: pistachio
+        quantity: 50
+        unit: grams
+        note: chopped
+      - id: mustard
+        quantity: 10
+        unit: milliliters
+      - id: honey
+        quantity: 10
+        unit: milliliters
+      - id: lemon-juice
+        note: ½ lemon
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: white-pepper
+        note: as needed
 serves: 2
 status: evergreen
 title: Pistachio-crusted salmon
@@ -13,17 +33,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Salmon fillets (2)
-- Chopped pistachios (50 g)
-- Mustard (10 ml)
-- Honey (10 ml)
-- Lemon juice (½ lemon)
-- Extra-virgin olive oil (as needed)
-- Salt (as needed)
-- White pepper (as needed)
-
 ## Steps
 
 1. Marinate the salmon in a baking dish with olive oil, lemon juice, salt, and pepper.

--- a/src/content/recipes/pollo-tikka-masala.mdx
+++ b/src/content/recipes/pollo-tikka-masala.mdx
@@ -4,39 +4,75 @@ aliases:
   - pollo-tikka-masala
 createdAt: 2025-08-23T15:19:00.000Z
 cuisine: indian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: chicken-breast
+        quantity: 1000
+        unit: grams
+  - group: Marinade
+    ingredients:
+      - id: greek-yogurt
+        quantity: 150
+        unit: grams
+      - id: fresh-ginger
+        quantity: 30
+        unit: grams
+        note: grated
+      - id: ground-garam-masala
+        quantity: 5
+        unit: grams
+      - id: smoked-paprika
+        quantity: 3
+        unit: grams
+      - id: garlic
+        quantity: 3
+        unit: clove
+      - id: lime-juice
+        note: ½ lime
+      - id: salt
+        quantity: 1
+        unit: pinch
+        note: fine
+  - group: Sauce
+    ingredients:
+      - id: tomato-passata
+        quantity: 350
+        unit: grams
+      - id: fresh-liquid-cream
+        quantity: 50
+        unit: grams
+      - id: white-onion
+        quantity: 1
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: fresh-chili
+        quantity: 1
+      - id: ground-cumin
+        quantity: 3
+        unit: grams
+      - id: smoked-paprika
+        quantity: 3
+        unit: grams
+      - id: ground-turmeric
+        quantity: 3
+        unit: grams
+      - id: brown-sugar
+        quantity: 20
+        unit: grams
+      - id: extra-virgin-olive-oil
+        quantity: 10
+        unit: grams
+      - id: salt
+        note: 'fine, to taste'
+      - id: fresh-coriander
+        note: 'or parsley, to taste'
 status: seedling
 title: Pollo tikka masala
 type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Chicken breast (1 kg)
-For the marinade:
-- Greek yogurt (150 g)
-- Fresh ginger (30 g, grated)
-- Garam masala (5 g)
-- Smoked paprika (3 g)
-- Garlic cloves (3)
-- Lime juice (½ lime)
-- Fine salt (1 pinch)
-For the sauce:
-- Tomato passata (350 g)
-- Fresh liquid cream (50 g)
-- White onion (1)
-- Garlic clove (1)
-- Fresh chili pepper (1)
-- Cumin (3 g)
-- Smoked paprika (3 g)
-- Ground turmeric (3 g)
-- Brown sugar (20 g)
-- Extra virgin olive oil (10 g)
-- Fine salt (to taste)
-- Fresh coriander or parsley (to taste)
-
 ## Steps
 
 1. Cut the chicken breast in half lengthwise and remove any fatty parts.

--- a/src/content/recipes/ponzu-sauce.mdx
+++ b/src/content/recipes/ponzu-sauce.mdx
@@ -4,8 +4,31 @@ aliases:
   - ponzu-sauce
 createdAt: 2026-01-03T12:35:00.000Z
 cuisine: asian
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: soy-sauce
+        quantity: 100
+        unit: milliliters
+      - id: lime-juice
+        quantity: 20
+        unit: milliliters
+      - id: lemon-juice
+        quantity: 20
+        unit: milliliters
+      - id: orange-juice
+        quantity: 15
+        unit: milliliters
+      - id: mirin
+        quantity: 20
+        unit: milliliters
+      - id: rice-vinegar
+        quantity: 5
+        unit: milliliters
+      - id: cornstarch
+        quantity: 7
+        unit: grams
+      - id: water
+        note: as needed
 serves: 2
 status: evergreen
 title: Ponzu sauce
@@ -13,17 +36,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Soy sauce (100 ml)
-- Lime juice (20 ml)
-- Lemon juice (20 ml)
-- Orange juice (15 ml)
-- Mirin (20 ml)
-- Rice vinegar (5 ml)
-- Corn starch (7 g)
-- Water (as needed)
-
 ## Steps
 
 1. Pour the soy sauce and lime juice into a small heavy-bottomed saucepan.

--- a/src/content/recipes/pork-tonkatsu.mdx
+++ b/src/content/recipes/pork-tonkatsu.mdx
@@ -4,8 +4,25 @@ aliases:
   - pork-tonkatsu
 createdAt: 2025-12-28T19:24:00.000Z
 cuisine: asian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: pork-loin-chops
+        quantity: 2
+        note: at least 1 cm thick
+      - id: salt
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
+      - id: all-purpose-flour
+        note: 'any kind, as needed'
+      - id: egg
+        quantity: 1
+      - id: vegetable-oil
+        note: 'for frying, as needed'
+      - id: panko
+        note: as needed
+      - id: tonkatsu-sauce
+        note: 'e.g., Bulldog, as needed'
 serves: 2
 status: evergreen
 title: Pork tonkatsu
@@ -13,17 +30,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pork loin chops (2, at least 1 cm thick)
-- Salt (to taste)
-- Black pepper (to taste)
-- Flour (any kind, as needed)
-- Egg (1)
-- Vegetable oil (for frying, as needed)
-- Panko (as needed)
-- Tonkatsu sauce (e.g., Bulldog, as needed)
-
 ## Steps
 
 1. Trim excess fat from the pork and make small cuts in the connective tissue between fat and meat. This helps the cutlet stay flat while frying.

--- a/src/content/recipes/potato-gateau.mdx
+++ b/src/content/recipes/potato-gateau.mdx
@@ -4,8 +4,40 @@ aliases:
   - potato-gateau
 createdAt: 2025-12-28T19:06:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 500
+        unit: grams
+      - id: fior-di-latte-mozzarella
+        quantity: 100
+        unit: grams
+      - id: cooked-ham
+        quantity: 50
+        unit: grams
+        note: or turkey breast
+      - id: parmigiano-reggiano
+        quantity: 30
+        unit: grams
+        note: 24 months
+      - id: egg
+        quantity: 2
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
+      - id: salt
+        note: as needed
+  - group: Dish and topping
+    ingredients:
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: breadcrumbs
+        quantity: 20
+        unit: grams
+      - id: parmigiano-reggiano
+        quantity: 30
+        unit: grams
 serves: 6
 status: evergreen
 title: Potato gâteau
@@ -13,23 +45,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Yellow-fleshed potatoes (500 g)
-- Fior di latte mozzarella (100 g)
-- Cooked ham or turkey breast (50 g)
-- Grated Parmigiano Reggiano DOP, 24 months (30 ml)
-- Eggs (2)
-- Extra-virgin olive oil (as needed)
-- Black pepper (as needed)
-- Fine salt (as needed)
-
-For the dish and topping:
-
-- Extra-virgin olive oil (as needed)
-- Breadcrumbs (20 g)
-- Parmigiano Reggiano DOP (30 g)
-
 ## Steps
 
 1. Boil the potatoes in plenty of cold water for 30-40 minutes, until tender.

--- a/src/content/recipes/potato-rosti.mdx
+++ b/src/content/recipes/potato-rosti.mdx
@@ -4,8 +4,18 @@ aliases:
   - potato-rosti
 createdAt: 2025-12-28T18:59:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: potato
+        quantity: 750
+        unit: grams
+      - id: butter
+        quantity: 55
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
 serves: 4
 status: evergreen
 title: Potato rösti
@@ -13,13 +23,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Red potatoes (750 g)
-- Butter (55 g)
-- Fine salt (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Put the potatoes in a pot with plenty of cold water.

--- a/src/content/recipes/pulled-mushroom-burger-with-coleslaw.mdx
+++ b/src/content/recipes/pulled-mushroom-burger-with-coleslaw.mdx
@@ -4,21 +4,19 @@ aliases:
   - pulled-mushroom-burger-with-coleslaw
 createdAt: 2025-12-28T19:19:00.000Z
 cuisine: bbq
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - 'note: ''Ingredients for [[coleslaw|Coleslaw]]'''
+      - 'note: ''Ingredients for [[pulled-mushroom|Pulled mushroom]]'''
+      - id: hamburger-bun
+        quantity: 2
 serves: 2
 status: evergreen
 title: Pulled mushroom burger with coleslaw
 type: main-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ingredients for [[coleslaw|Coleslaw]]
-- Ingredients for [[pulled-mushroom|Pulled mushroom]]
-- Hamburger buns (2)
-
 ## Steps
 
 1. Make the [[coleslaw|Coleslaw]].

--- a/src/content/recipes/pulled-mushroom.mdx
+++ b/src/content/recipes/pulled-mushroom.mdx
@@ -4,8 +4,37 @@ aliases:
   - pulled-mushroom
 createdAt: 2025-12-28T19:16:00.000Z
 cuisine: bbq
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: oyster-mushrooms
+        quantity: 500
+        unit: grams
+        note: pleurotus
+      - id: soy-sauce
+        quantity: 1
+        unit: small espresso cup
+      - id: barbecue-sauce
+        quantity: 30
+        unit: milliliters
+      - id: rice-vinegar
+        quantity: 15
+        unit: milliliters
+      - id: vegetarian-oyster-sauce
+        quantity: 15
+        unit: milliliters
+      - id: sesame-oil
+        quantity: 15
+        unit: milliliters
+      - id: granulated-sugar
+        quantity: 5
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: salt
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: as needed
 serves: 2
 status: evergreen
 title: Pulled mushroom
@@ -13,19 +42,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Oyster mushrooms (pleurotus) (500 g)
-- Soy sauce (1 small espresso cup)
-- BBQ sauce (30 ml)
-- Rice vinegar (15 ml)
-- Vegetarian oyster sauce (15 ml)
-- Sesame oil (15 ml)
-- Sugar (5 ml)
-- Garlic clove (1)
-- Salt (to taste)
-- Extra-virgin olive oil (as needed)
-
 ## Steps
 
 1. Remove any dirt and tough stem parts from the mushrooms. Rinse quickly under cold water (don’t soak).

--- a/src/content/recipes/pumpkin-and-gorgonzola-risotto.mdx
+++ b/src/content/recipes/pumpkin-and-gorgonzola-risotto.mdx
@@ -4,8 +4,42 @@ aliases:
   - pumpkin-and-gorgonzola-risotto
 createdAt: 2025-12-28T19:16:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: carnaroli-rice
+        quantity: 320
+        unit: grams
+      - id: delica-pumpkin
+        quantity: 600
+        unit: grams
+        note: cleaned
+      - id: gorgonzola
+        quantity: 170
+        unit: grams
+        note: cold from the fridge
+      - id: golden-onion
+        quantity: 100
+        unit: grams
+      - id: butter
+        quantity: 30
+        unit: grams
+        note: cold
+      - id: dry-white-wine
+        quantity: 50
+        unit: milliliters
+      - id: extra-virgin-olive-oil
+        quantity: 20
+        unit: milliliters
+      - id: rosemary
+        quantity: 1
+        unit: sprig
+      - id: salt
+        note: 'fine, as needed'
+      - id: black-peppercorns
+        note: as needed
+      - id: vegetable-stock
+        quantity: 2500
+        unit: milliliters
 serves: 4
 status: evergreen
 title: Pumpkin and gorgonzola risotto
@@ -13,20 +47,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Carnaroli rice (320 g)
-- Delica pumpkin, cleaned (600 g)
-- Gorgonzola, cold from the fridge (170 g)
-- Golden onion (100 g)
-- Cold butter (30 g)
-- White wine (50 ml)
-- Extra-virgin olive oil (20 ml)
-- Rosemary (1 sprig)
-- Fine salt (as needed)
-- Black pepper (as needed)
-- Vegetable stock (2.5 lt)
-
 ## Steps
 
 1. Clean the pumpkin, removing the peel, seeds, and stringy parts.

--- a/src/content/recipes/pumpkin-and-sausage-risotto.mdx
+++ b/src/content/recipes/pumpkin-and-sausage-risotto.mdx
@@ -4,8 +4,46 @@ aliases:
   - pumpkin-and-sausage-risotto
 createdAt: 2025-12-28T19:22:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: carnaroli-rice
+        quantity: 320
+        unit: grams
+      - id: delica-pumpkin
+        quantity: 500
+        unit: grams
+        note: 'frozen diced, e.g. Orogel'
+      - id: sausage
+        quantity: 300
+        unit: grams
+      - id: shallot
+        quantity: 1
+      - id: vegetable-stock
+        quantity: 1000
+        unit: milliliters
+      - id: dry-white-wine
+        quantity: 40
+        unit: milliliters
+      - id: butter
+        quantity: 50
+        unit: grams
+        note: split 20 g + 30 g
+      - id: parmigiano-reggiano
+        quantity: 40
+        unit: grams
+        note: grated
+      - id: extra-virgin-olive-oil
+        quantity: 20
+        unit: milliliters
+      - id: sweet-paprika
+        quantity: 5
+        unit: milliliters
+      - id: rosemary
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
 serves: 4
 status: evergreen
 title: Pumpkin and sausage risotto
@@ -13,22 +51,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Carnaroli rice (320 g)
-- Frozen diced pumpkin, e.g. Orogel (500 g)
-- Sausage (300 g)
-- Shallot (1)
-- Vegetable stock (1 lt)
-- White wine (40 ml)
-- Butter (50 g, split 20 g + 30 g)
-- Grated Parmigiano Reggiano DOP (40 g)
-- Extra-virgin olive oil (20 ml)
-- Sweet paprika (5 ml)
-- Rosemary (as needed)
-- Salt (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Peel the shallot and slice thinly.

--- a/src/content/recipes/pumpkin-muffins.mdx
+++ b/src/content/recipes/pumpkin-muffins.mdx
@@ -4,8 +4,36 @@ aliases:
   - pumpkin-muffins
 createdAt: 2025-12-28T19:15:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: delica-pumpkin
+        quantity: 250
+        unit: grams
+        note: cleaned
+      - id: granulated-sugar
+        quantity: 200
+        unit: grams
+      - id: egg
+        quantity: 2
+      - id: vegetable-oil
+        quantity: 130
+        unit: grams
+        note: neutral
+      - id: potato-starch
+        quantity: 70
+        unit: grams
+      - id: 00-flour
+        quantity: 250
+        unit: grams
+      - id: baking-powder
+        quantity: 16
+        unit: grams
+      - id: nutmeg
+        note: as needed
+      - id: ground-cinnamon
+        note: as needed
+      - id: powdered-sugar
+        note: 'as needed, for decorating'
 serves: 12
 status: evergreen
 title: Pumpkin muffins
@@ -13,19 +41,6 @@ type: dessert
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Cleaned pumpkin (250 g)
-- Sugar (200 g)
-- Eggs (2)
-- Neutral vegetable oil (130 g)
-- Potato starch (70 g)
-- 00 flour (250 g)
-- Baking powder (16 g)
-- Nutmeg (as needed)
-- Ground cinnamon (as needed)
-- Powdered sugar (as needed, for decorating)
-
 ## Steps
 
 1. Crack the eggs into the food processor bowl, add the sugar, and blend until smooth.

--- a/src/content/recipes/pumpkin-speck-and-provola-strudel.mdx
+++ b/src/content/recipes/pumpkin-speck-and-provola-strudel.mdx
@@ -4,25 +4,36 @@ aliases:
   - pumpkin-speck-and-provola-strudel
 createdAt: 2025-12-28T19:18:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: puff-pastry-sheet
+        quantity: 1
+        unit: sheet
+      - id: delica-pumpkin
+        quantity: 80
+        unit: grams
+        note: net weight
+      - id: speck
+        quantity: 100
+        unit: grams
+        note: thinly sliced
+      - id: sweet-provola
+        quantity: 100
+        unit: grams
+      - id: egg-yolk
+        quantity: 1
+        unit: clove
+      - id: milk
+        note: 'a splash, for brushing'
+      - id: sesame-or-poppy-seeds
+        note: to taste
 serves: 2
 status: evergreen
 title: 'Pumpkin, speck, and provola strudel'
 type: single-dish
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Round puff pastry sheet (1)
-- Pumpkin, net weight (80 g)
-- Speck, thinly sliced (100 g)
-- Sweet provola (100 g)
-- Egg yolk (1)
-- Milk (a splash, for brushing)
-- Sesame or poppy seeds (to taste)
-
 ## Steps
 
 1. Remove the peel and seeds from the pumpkin, then slice it as thinly as possible (1-2 mm).

--- a/src/content/recipes/ragu.mdx
+++ b/src/content/recipes/ragu.mdx
@@ -4,33 +4,53 @@ aliases:
   - ragu
 createdAt: 2025-04-06T15:09:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: ground-beef
+        quantity: 250
+        unit: grams
+      - id: pork-ribs
+        quantity: 100
+        unit: grams
+      - id: sausage
+        quantity: 1
+      - id: beef-short-rib
+        quantity: 100
+        unit: grams
+      - id: lean-beef
+        quantity: 100
+        unit: grams
+      - id: ossobuco
+        quantity: 1
+      - id: veal-bones
+        quantity: 3
+      - id: celery-stalk
+        quantity: 1
+      - id: carrot
+        quantity: 2
+      - id: onion
+        quantity: 1
+      - id: tomato-paste
+        quantity: 30
+        unit: milliliters
+      - id: tomato-passata
+        quantity: 350
+        unit: grams
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: red-wine
+        quantity: 0.5
+        unit: glass
 status: seedling
 title: Ragù
 type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ground beef (250 g)
-- Pork ribs (100 g)
-- Sausage (1)
-- Beef short rib (100 g)
-- Lean beef (100 g)
-- Ossobuco (1)
-- Veal bones (3)
-- Celery (1)
-- Carrots (2)
-- Onion (1)
-- Triple-concentrated tomato paste (30 ml)
-- Tomato passata (350 g)
-- Salt (to taste)
-- Pepper (to taste)
-- Extra virgin olive oil (to taste)
-- Red wine (½ glass)
-
 ## Steps
 
 1. Chop the celery, carrot, and onion and sauté them in a separate pot with a bit of extra virgin olive oil and salt.

--- a/src/content/recipes/rice-with-teriyaki-pork-loin.mdx
+++ b/src/content/recipes/rice-with-teriyaki-pork-loin.mdx
@@ -4,8 +4,50 @@ aliases:
   - rice-with-teriyaki-pork-loin
 createdAt: 2025-12-27T19:24:00.000Z
 cuisine: asian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: basmati-rice
+        note: 150-180 g
+      - id: pork-loin-chops
+        note: 200-250 g
+      - id: zucchini
+        quantity: 1
+      - id: carrot
+        quantity: 2
+        note: large
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: fresh-ginger
+        note: a small piece
+      - id: soy-sauce
+        quantity: 15
+        unit: milliliters
+      - id: barbecue-sauce
+        quantity: 5
+        unit: milliliters
+      - id: granulated-sugar
+        note: as needed
+      - id: sesame-or-poppy-seeds
+        note: as needed
+      - id: sunflower-oil
+        note: as needed
+      - id: salt
+        note: as needed
+  - group: Sauce
+    ingredients:
+      - id: soy-sauce
+        quantity: 15
+        unit: milliliters
+      - id: barbecue-sauce
+        quantity: 5
+        unit: milliliters
+      - id: granulated-sugar
+        quantity: 1
+        unit: pinch
+      - id: water
+        quantity: 5
+        unit: milliliters
 serves: 2
 status: budding
 title: Rice with teriyaki pork loin
@@ -13,28 +55,6 @@ type: single-dish
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Basmati rice (150-180 g)
-- Pork loin slices (200-250 g)
-- Zucchini (1)
-- Large carrots (2)
-- Garlic cloves (2)
-- Fresh ginger (a small piece)
-- Soy sauce (15 ml)
-- BBQ sauce (5 ml)
-- Sugar (as needed)
-- Sesame seeds (as needed)
-- Sunflower oil (as needed)
-- Salt (as needed)
-
-For the sauce:
-
-- Soy sauce (15 ml)
-- BBQ sauce (5 ml)
-- Sugar (1 pinch)
-- Water (5 ml)
-
 ## Steps
 
 1. Cut the pork loin into thin strips.

--- a/src/content/recipes/ricotta-and-saffron-pasta.mdx
+++ b/src/content/recipes/ricotta-and-saffron-pasta.mdx
@@ -4,8 +4,23 @@ aliases:
   - ricotta-and-saffron-pasta
 createdAt: 2026-04-04T18:13:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: spaghettoni
+        quantity: 320
+        unit: grams
+      - id: cow-ricotta
+        quantity: 250
+        unit: grams
+      - id: saffron
+        quantity: 2
+        unit: sachet
+      - id: sage
+        note: to taste
+      - id: salt
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
 serves: 4
 status: budding
 title: Ricotta and saffron pasta
@@ -13,15 +28,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghettoni (320 g)
-- Cow’s milk ricotta (250 g)
-- Saffron (2 sachets)
-- Fresh sage (to taste)
-- Fine salt (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. Bring a large pot of salted water to the boil and cook the spaghettoni until al dente.

--- a/src/content/recipes/salmon-and-pistachio-tartare.mdx
+++ b/src/content/recipes/salmon-and-pistachio-tartare.mdx
@@ -4,23 +4,28 @@ aliases:
   - salmon-and-pistachio-tartare
 createdAt: 2026-01-03T12:50:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: salmon-fillet
+        quantity: 250
+        unit: grams
+        note: previously frozen / sushi-grade
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: lemon-juice
+        note: to taste
+      - id: pistachio
+        note: 'chopped, to taste'
+      - id: salt
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
 status: evergreen
 title: Salmon and pistachio tartare
 type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Fresh salmon fillet (250 g, previously frozen / sushi-grade)
-- Extra virgin olive oil (to taste)
-- Lemon juice (to taste)
-- Chopped pistachios (to taste)
-- Salt (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. Make sure the salmon fillet has been properly frozen for safety. If using fresh salmon, freeze it at −20 °C for at least 24 hours, then thaw it in the refrigerator.

--- a/src/content/recipes/sausage-and-potatoes.mdx
+++ b/src/content/recipes/sausage-and-potatoes.mdx
@@ -4,8 +4,26 @@ aliases:
   - sausage-and-potatoes
 createdAt: 2025-12-28T19:21:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: sausage
+        quantity: 600
+        unit: grams
+      - id: potato
+        quantity: 500
+        unit: grams
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: salt
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
+      - id: rosemary
+        quantity: 1
+        unit: sprig
+      - id: garlic
+        quantity: 2
+        unit: clove
 serves: 4
 status: evergreen
 title: Sausage and potatoes
@@ -13,16 +31,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Sausage (600 g)
-- Potatoes (500 g)
-- Extra-virgin olive oil (as needed)
-- Salt (to taste)
-- Black pepper (to taste)
-- Rosemary (1 sprig)
-- Garlic cloves (2)
-
 ## Steps
 
 1. Peel the potatoes, rinse, pat dry, and cut into wedges.

--- a/src/content/recipes/seitan-scallopini-with-mushrooms.mdx
+++ b/src/content/recipes/seitan-scallopini-with-mushrooms.mdx
@@ -4,8 +4,28 @@ aliases:
   - seitan-scallopini-with-mushrooms
 createdAt: 2025-12-28T19:21:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: seitan
+        quantity: 1
+        unit: pack
+      - id: champignon-mushrooms
+        quantity: 400
+        unit: grams
+      - id: all-purpose-flour
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: parsley
+        note: as needed
+      - id: dry-white-wine
+        quantity: 120
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        note: as needed
 serves: 2
 status: evergreen
 title: Seitan scallopini with mushrooms
@@ -13,17 +33,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Seitan (1 pack)
-- Mushrooms (400 g)
-- Flour (as needed)
-- Salt (as needed)
-- Parsley (as needed)
-- White wine (120 ml)
-- Garlic clove (1)
-- Extra-virgin olive oil (as needed)
-
 ## Steps
 
 1. Clean and slice the mushrooms.

--- a/src/content/recipes/shrimp-stock.mdx
+++ b/src/content/recipes/shrimp-stock.mdx
@@ -4,8 +4,16 @@ aliases:
   - shrimp-stock
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: water
+        quantity: 250
+        unit: milliliters
+      - id: shrimp-head
+        note: 8–9
+      - id: tomato-passata
+        quantity: 50
+        unit: milliliters
 serves: 2
 status: evergreen
 title: Shrimp stock
@@ -13,12 +21,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Water (250 ml)
-- Shrimp heads (8–9)
-- Tomato passata (50 ml)
-
 ## Steps
 
 1. (to be filled)

--- a/src/content/recipes/spaghetti-aglio-e-olio.mdx
+++ b/src/content/recipes/spaghetti-aglio-e-olio.mdx
@@ -4,8 +4,22 @@ aliases:
   - spaghetti-aglio-e-olio
 createdAt: 2026-01-03T12:51:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+      - id: garlic
+        quantity: 3
+        unit: clove
+      - id: fresh-chili
+        quantity: 3
+      - id: extra-virgin-olive-oil
+        quantity: 70
+        unit: grams
+        note: high quality
+      - id: salt
+        note: to taste
 serves: 4
 status: evergreen
 title: Spaghetti aglio e olio
@@ -13,14 +27,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti (320 g)
-- Garlic cloves (3)
-- Fresh chili peppers (3)
-- Extra-virgin olive oil (70 g, high quality)
-- Fine salt (to taste)
-
 ## Steps
 
 1. Bring a large pot of water to a boil, salt it to taste, and cook the spaghetti until al dente.

--- a/src/content/recipes/spaghetti-alla-nerano.mdx
+++ b/src/content/recipes/spaghetti-alla-nerano.mdx
@@ -4,27 +4,43 @@ aliases:
   - spaghetti-alla-nerano
 createdAt: 2025-08-23T15:23:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+      - id: zucchini
+        quantity: 700
+        unit: grams
+      - id: provolone-del-monaco
+        quantity: 150
+        unit: grams
+        note: coarsely grated
+      - id: parmigiano-reggiano
+        quantity: 30
+        unit: grams
+        note: grated
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        quantity: 30
+        unit: grams
+        note: for sautéing
+      - id: extra-virgin-olive-oil
+        note: 'as needed, for frying the zucchini'
+      - id: fresh-basil
+        note: to taste
+      - id: salt
+        note: 'to taste, fine salt'
+      - id: black-peppercorns
+        note: to taste
 status: seedling
 title: Spaghetti alla nerano
 type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti (320 g)
-- Zucchini (700 g)
-- Provolone del Monaco (150 g, coarsely grated)
-- Grated Parmigiano Reggiano DOP (30 g)
-- Garlic clove (1)
-- Extra virgin olive oil (30 g, for sautéing)
-- Extra virgin olive oil (as needed, for frying the zucchini)
-- Fresh basil (to taste)
-- Fine salt (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. Wash and trim the zucchini, then slice them into thin rounds with a mandolin.

--- a/src/content/recipes/spaghetti-cacio-e-pepe.mdx
+++ b/src/content/recipes/spaghetti-cacio-e-pepe.mdx
@@ -4,8 +4,18 @@ aliases:
   - spaghetti-cacio-e-pepe
 createdAt: 2025-12-28T18:58:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: spaghettoni
+        quantity: 80
+        unit: grams
+        note: or tonnarelli
+      - id: pecorino-romano
+        quantity: 50
+        unit: grams
+        note: medium-aged
+      - id: black-peppercorns
+        note: as needed
 serves: 1
 status: evergreen
 title: Spaghetti cacio e pepe
@@ -13,12 +23,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti or tonnarelli (80 g)
-- Medium-aged pecorino romano (50 g)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Cook the pasta using 500 ml water for every 80 g pasta. If needed, use a small or narrow pot so the pasta is covered even with little water.

--- a/src/content/recipes/spaghetti-carbonara.mdx
+++ b/src/content/recipes/spaghetti-carbonara.mdx
@@ -4,8 +4,27 @@ aliases:
   - spaghetti-carbonara
 createdAt: 2026-01-04T18:11:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: egg-yolk
+        quantity: 4
+      - id: egg
+        quantity: 2
+      - id: parmigiano-reggiano
+        quantity: 180
+        unit: grams
+        note: 36 months
+      - id: pecorino-romano
+        quantity: 120
+        unit: grams
+      - id: guanciale
+        note: as needed or pancetta
+      - id: spaghettoni
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: black-peppercorns
+        note: 'to taste, Tellicherry / Lungo del Bengala / your choice'
 serves: 6
 status: evergreen
 title: Spaghetti carbonara
@@ -13,17 +32,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Egg yolks (4)
-- Whole eggs (2)
-- Parmigiano Reggiano (180 g, 36 months)
-- Pecorino romano (120 g)
-- Guanciale or pancetta (as needed)
-- Spaghetti (as needed)
-- Salt (as needed)
-- Black pepper (to taste, Tellicherry / Lungo del Bengala / your choice)
-
 ## Steps
 
 1. In a heatproof bowl, add 2 whole eggs and 4 yolks.

--- a/src/content/recipes/spaghetti-puttanesca.mdx
+++ b/src/content/recipes/spaghetti-puttanesca.mdx
@@ -4,8 +4,39 @@ aliases:
   - spaghetti-puttanesca
 createdAt: 2026-05-23T17:18:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: spaghettoni
+        quantity: 320
+        unit: grams
+      - id: peeled-tomatoes
+        quantity: 800
+        unit: grams
+        note: canned
+      - id: anchovy-fillets
+        quantity: 25
+        unit: grams
+        note: in oil
+      - id: capers
+        quantity: 10
+        unit: grams
+        note: salt-packed
+      - id: parsley
+        quantity: 1
+        unit: bunch
+      - id: gaeta-olives
+        quantity: 100
+        unit: grams
+      - id: garlic
+        quantity: 3
+        unit: clove
+      - id: dried-chili-pepper
+        quantity: 2
+      - id: extra-virgin-olive-oil
+        quantity: 30
+        unit: grams
+      - id: salt
+        note: to taste
 serves: 4
 status: evergreen
 title: Spaghetti puttanesca
@@ -13,19 +44,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Large square spaghetti (320 g)
-- Canned peeled tomatoes (800 g)
-- Anchovy fillets in oil (25 g)
-- Salt-packed capers (10 g)
-- Flat-leaf parsley (1 bunch)
-- Gaeta olives (100 g)
-- Garlic (3 cloves)
-- Dried chili peppers (2)
-- Extra virgin olive oil (30 g)
-- Fine salt (to taste)
-
 ## Steps
 
 1. Rinse the capers under running water to remove excess salt, then pat dry and roughly chop with a knife.

--- a/src/content/recipes/spaghetti-with-butter-and-anchovies.mdx
+++ b/src/content/recipes/spaghetti-with-butter-and-anchovies.mdx
@@ -4,8 +4,26 @@ aliases:
   - spaghetti-with-butter-and-anchovies
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+        note: spaghetti
+      - id: butter
+        quantity: 70
+        unit: grams
+      - id: anchovy-fillets
+        quantity: 80
+        unit: grams
+        note: in oil
+      - id: panko
+        quantity: 30
+        unit: grams
+      - id: salt
+        note: as needed
+      - id: parsley
+        note: as needed
 serves: 4
 status: evergreen
 title: Spaghetti with butter and anchovies
@@ -13,15 +31,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti (320 g)
-- Butter (70 g)
-- Anchovies in oil (80 g)
-- Panko (30 g)
-- Salt (as needed)
-- Parsley (as needed)
-
 ## Steps
 
 1. Bring a pot of salted water to a boil and cook the pasta.

--- a/src/content/recipes/spaghetti-with-mussels.mdx
+++ b/src/content/recipes/spaghetti-with-mussels.mdx
@@ -4,8 +4,37 @@ aliases:
   - spaghetti-with-mussels
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: mussels
+        quantity: 500
+        unit: grams
+      - id: spaghetti
+        quantity: 200
+        unit: grams
+        note: no. 5
+      - id: garlic
+        quantity: 2
+        unit: clove
+      - id: parsley
+        quantity: 2
+        unit: bunch
+      - id: dry-white-wine
+        quantity: 125
+        unit: milliliters
+      - id: fresh-chili
+        quantity: 1
+        note: optional
+      - id: salt
+        note: as needed
+      - id: pepper
+        note: as needed
+      - id: peeled-tomatoes
+        quantity: 400
+        unit: grams
+        note: 'canned, chopped'
+      - id: olive-oil
+        note: as needed
 serves: 2
 status: budding
 title: Spaghetti with mussels
@@ -13,19 +42,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Mussels (500 g)
-- Spaghetti (200 g, no. 5)
-- Garlic cloves (2)
-- Parsley (2 bunches)
-- White wine (½ glass)
-- Chili pepper (1, optional)
-- Salt (as needed)
-- Pepper (as needed)
-- Canned peeled tomatoes (400 g, chopped)
-- Olive oil (as needed)
-
 ## Steps
 
 1. Scrub the mussel shells with a small knife (or another mussel).

--- a/src/content/recipes/spaghetti-with-pesto-cherry-tomatoes-and-mullet-bottarga.mdx
+++ b/src/content/recipes/spaghetti-with-pesto-cherry-tomatoes-and-mullet-bottarga.mdx
@@ -4,25 +4,33 @@ aliases:
   - spaghetti-with-pesto-cherry-tomatoes-and-mullet-bottarga
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: spaghetti
+        quantity: 300
+        unit: grams
+      - id: cherry-tomato
+        quantity: 250
+        unit: grams
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: genovese-pesto
+        quantity: 30
+        unit: milliliters
+      - id: mullet-bottarga
+        note: to taste
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: fresh-basil
+        note: to taste
 serves: 3
 status: evergreen
 title: 'Spaghetti with pesto, cherry tomatoes, and mullet bottarga'
 type: first-course
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spaghetti (300 g)
-- Cherry tomatoes (250 g)
-- Garlic (1 clove)
-- Genovese pesto (30 ml)
-- Mullet bottarga (to taste)
-- Extra-virgin olive oil (to taste)
-- Fresh basil (to taste)
-
 ## Steps
 
 1. Put the garlic in a nonstick pan (whole or chopped, depending on preference).

--- a/src/content/recipes/spatzle-with-guanciale-and-parmesan-cream.mdx
+++ b/src/content/recipes/spatzle-with-guanciale-and-parmesan-cream.mdx
@@ -4,20 +4,20 @@ aliases:
   - spatzle-with-guanciale-and-parmesan-cream
 createdAt: 2025-12-28T19:22:00.000Z
 cuisine: mediterranean
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: spinach
+        note: 'spätzle, as needed'
+      - id: parmigiano-reggiano
+        note: as needed
+      - id: guanciale
+        note: as needed
 status: evergreen
 title: Spätzle with guanciale and Parmesan cream
 type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Spinach spätzle (as needed)
-- Parmigiano Reggiano (as needed)
-- Guanciale (as needed)
-
 ## Steps
 
 1. Bring a pot of salted water to a boil.

--- a/src/content/recipes/spinach-and-sun-dried-tomato-quiche.mdx
+++ b/src/content/recipes/spinach-and-sun-dried-tomato-quiche.mdx
@@ -4,8 +4,21 @@ aliases:
   - spinach-and-sun-dried-tomato-quiche
 createdAt: 2025-12-31T10:06:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: pine-nuts
+        note: as needed
+      - id: puff-pastry-sheet
+        quantity: 1
+        unit: sheet
+      - id: spinach
+        quantity: 250
+        unit: grams
+      - id: sun-dried-tomatoes
+        note: as needed
+      - id: vegan-ricotta
+        quantity: 200
+        unit: grams
 serves: 6
 status: evergreen
 title: Spinach and sun-dried tomato quiche
@@ -13,14 +26,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pine nuts (as needed)
-- Puff pastry (1 sheet)
-- Spinach (250 g)
-- Sun-dried tomatoes (as needed)
-- Vegan ricotta (200 g)
-
 ## Steps
 
 1. Cut the puff pastry into circles using a muffin tin as a size guide.

--- a/src/content/recipes/stuffed-calamari.mdx
+++ b/src/content/recipes/stuffed-calamari.mdx
@@ -4,8 +4,48 @@ aliases:
   - stuffed-calamari
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: squid
+        quantity: 8
+        unit: count
+        note: about 720 g
+      - id: dry-white-wine
+        quantity: 30
+        unit: grams
+        note: for cooking
+      - id: parsley
+        note: as needed
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: sea-salt
+        note: as needed
+      - id: lemon-zest
+        note: as needed
+  - group: Filling
+    ingredients:
+      - id: breadcrumbs
+        quantity: 100
+        unit: grams
+      - id: parmigiano-reggiano
+        quantity: 30
+        unit: grams
+      - id: anchovy-fillets
+        quantity: 6
+        unit: count
+        note: in oil
+      - id: egg
+        quantity: 1
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: dry-white-wine
+        quantity: 30
+        unit: grams
+      - id: parsley
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
 serves: 4
 status: evergreen
 title: Stuffed calamari
@@ -13,24 +53,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Calamari (8, about 720 g)
-- White wine (30 g, for cooking)
-- Parsley (as needed)
-- Extra-virgin olive oil (as needed)
-- Fine salt (as needed)
-- Lemon zest (as needed)
-For the filling:
-- Bread crumb (100 g)
-- Parmigiano Reggiano (30 g)
-- Anchovy fillets in oil (6)
-- Egg (1)
-- Garlic clove (1)
-- White wine (30 g)
-- Parsley (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Clean the calamari: separate head and body, remove innards and the transparent quill, rinse well.

--- a/src/content/recipes/tonkatsu-sauce.mdx
+++ b/src/content/recipes/tonkatsu-sauce.mdx
@@ -4,8 +4,24 @@ aliases:
   - tonkatsu-sauce
 createdAt: 2026-01-03T12:50:00.000Z
 cuisine: asian
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: ketchup
+        quantity: 60
+        unit: milliliters
+      - id: worcestershire-sauce
+        quantity: 30
+        unit: milliliters
+      - id: oyster-sauce
+        quantity: 15
+        unit: milliliters
+      - id: granulated-sugar
+        quantity: 15
+        unit: milliliters
+      - id: dashi-powder
+        quantity: 2.5
+        unit: milliliters
+        note: optional
 serves: 4
 status: evergreen
 title: Tonkatsu sauce
@@ -13,14 +29,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ketchup (60 ml)
-- Worcestershire sauce (30 ml)
-- Oyster sauce (15 ml)
-- Sugar (15 ml)
-- Dashi powder (2.5 ml, optional)
-
 ## Steps
 
 1. Mix all the ingredients in a bowl until the sugar and the dashi powder are completely dissolved.

--- a/src/content/recipes/tonnato-sauce.mdx
+++ b/src/content/recipes/tonnato-sauce.mdx
@@ -4,8 +4,29 @@ aliases:
   - tonnato-sauce
 createdAt: 2026-04-11T09:11:00.000Z
 cuisine: italian
-diets:
-  - omnivore
+ingredient_groups:
+  - ingredients:
+      - id: egg
+        quantity: 2
+        note: medium
+      - id: canned-tuna-in-oil
+        quantity: 200
+        unit: grams
+        note: drained
+      - id: capers
+        quantity: 5
+        unit: grams
+        note: salted
+      - id: anchovy-fillets
+        quantity: 3
+        unit: fillets
+        note: 'in oil, drained'
+      - id: meat-broth
+        quantity: 150
+        unit: grams
+        note: at room temperature
+      - id: caper-berries
+        note: 'to garnish, optional'
 serves: 4
 status: evergreen
 title: Tonnato sauce
@@ -13,15 +34,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Medium eggs (2)
-- Canned tuna in oil (200 g, drained)
-- Salted capers (5 g)
-- Anchovies in oil (3 fillets, drained)
-- Meat broth (150 g, at room temperature)
-- Caper berries (to garnish, optional)
-
 ## Steps
 
 1. Prepare the meat broth in advance and allow it to cool to room temperature before using.

--- a/src/content/recipes/tonnato-veal.mdx
+++ b/src/content/recipes/tonnato-veal.mdx
@@ -4,40 +4,52 @@ aliases:
   - tonnato-veal
 createdAt: 2026-03-29T17:18:00.000Z
 cuisine: italian
-diets:
-  - omnivore
+ingredient_groups:
+  - group: Veal
+    ingredients:
+      - id: beef-topside
+        quantity: 800
+        unit: grams
+      - id: celery-stalk
+        quantity: 1
+      - id: carrot
+        quantity: 1
+      - id: golden-onion
+        quantity: 1
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: dry-white-wine
+        quantity: 250
+        unit: milliliters
+      - id: water
+        quantity: 1500
+        unit: milliliters
+      - id: bay-leaves
+        quantity: 1
+      - id: cloves
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
+      - id: extra-virgin-olive-oil
+        quantity: 45
+        unit: milliliters
+      - id: salt
+        note: 'fine, to taste'
+  - group: Garnish
+    ingredients:
+      - id: caper-berries
+        note: to taste
+  - group: Sauce
+    ingredients:
+      - 'note: ''See [[tonnato-sauce|Tonnato sauce]]'''
 serves: 6
 status: budding
 title: Tonnato veal
 type: starter
-updatedAt: 2026-05-25T05:55:03.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the veal:
-
-- Veal, topside/round roast (800 g)
-- Celery (1 stalk)
-- Carrot (1)
-- Golden onion (1)
-- Garlic (1 clove)
-- Dry white wine (250 g)
-- Water (1.5 lt)
-- Bay leaf (1)
-- Cloves (to taste)
-- Black peppercorns (to taste)
-- Extra virgin olive oil (45 ml)
-- Fine salt (to taste)
-
-For garnish:
-
-- Caper berries (to taste)
-
-For the sauce:
-
-- See [[tonnato-sauce|Tonnato sauce]]
-
 ## Steps
 
 1. Make the tuna sauce — see [[tonnato-sauce|Tonnato sauce]].

--- a/src/content/recipes/tortiglioni-with-radicchio-and-walnuts.mdx
+++ b/src/content/recipes/tortiglioni-with-radicchio-and-walnuts.mdx
@@ -4,8 +4,37 @@ aliases:
   - tortiglioni-with-radicchio-and-walnuts
 createdAt: 2025-12-28T19:00:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 400
+        unit: grams
+        note: type of your choice
+      - id: red-onion
+        quantity: 1
+      - id: radicchio
+        quantity: 1
+        unit: head
+      - id: walnuts
+        quantity: 70
+        unit: grams
+      - id: vegan-grated-cheese
+        quantity: 30
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: sage
+        note: a couple
+      - id: rosemary
+        unit: sprigs
+        note: a few
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: salt
+        note: as needed
+      - id: walnuts
+        note: 'chopped, to finish'
 serves: 4
 status: evergreen
 title: Tortiglioni with radicchio and walnuts
@@ -13,20 +42,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Pasta, type of your choice (400 g)
-- Red onion (1)
-- Radicchio (1 head)
-- Walnuts (70 g)
-- Grated vegan cheese (30 ml)
-- Garlic (1 clove)
-- Sage leaves (a couple)
-- Rosemary sprigs (a few)
-- Extra-virgin olive oil (as needed)
-- Salt (as needed)
-- Chopped walnuts (to finish)
-
 ## Steps
 
 1. Slice the red onion thinly.

--- a/src/content/recipes/tuna-and-mayonnaise-stuffed-eggs.mdx
+++ b/src/content/recipes/tuna-and-mayonnaise-stuffed-eggs.mdx
@@ -4,8 +4,22 @@ aliases:
   - tuna-and-mayonnaise-stuffed-eggs
 createdAt: 2025-12-30T10:35:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: egg
+        quantity: 6
+      - id: canned-tuna-in-oil
+        quantity: 80
+        unit: grams
+      - id: mayonnaise
+        quantity: 45
+        unit: milliliters
+      - id: worcestershire-sauce
+        note: a few drops
+      - id: black-peppercorns
+        note: to taste
+      - id: parsley
+        note: 'chopped, to taste'
 serves: 6
 status: evergreen
 title: Tuna and mayonnaise stuffed eggs
@@ -13,15 +27,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:03.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Eggs (6)
-- Canned tuna in oil (80 g)
-- Mayonnaise (45 ml)
-- Worcestershire sauce (a few drops)
-- Black pepper (to taste)
-- Chopped parsley (to taste)
-
 ## Steps
 
 1. Boil the eggs for 8 minutes from the moment the water reaches a boil.

--- a/src/content/recipes/tuna-mezze-maniche.mdx
+++ b/src/content/recipes/tuna-mezze-maniche.mdx
@@ -4,8 +4,38 @@ aliases:
   - tuna-mezze-maniche
 createdAt: 2026-03-28T15:41:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: pasta
+        quantity: 320
+        unit: grams
+      - id: canned-tuna-in-oil
+        quantity: 250
+        unit: grams
+        note: drained
+      - id: tomato-passata
+        quantity: 400
+        unit: grams
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: parsley
+        quantity: 1
+        unit: bunch
+        note: 'small, to chop'
+      - id: fresh-chili
+        quantity: 1
+      - id: extra-virgin-olive-oil
+        quantity: 40
+        unit: grams
+      - id: anchovy-fillets
+        quantity: 15
+        unit: grams
+        note: drained
+      - id: salt
+        note: to taste
+      - id: pepper
+        note: to taste
 serves: 4
 status: evergreen
 title: Tuna mezze maniche
@@ -13,19 +43,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Mezze maniche rigate (320 g)
-- Canned tuna in olive oil, drained (250 g)
-- Tomato passata (400 g)
-- Garlic (1 clove)
-- Fresh parsley (1 small bunch, to chop)
-- Fresh chilli pepper (1)
-- Extra virgin olive oil (40 g)
-- Anchovy fillets in oil, drained (15 g)
-- Salt (to taste)
-- Pepper (to taste)
-
 ## Steps
 
 1. Bring a large pot of water to the boil, salt it generously, and set it aside ready to cook the pasta.

--- a/src/content/recipes/tuna-tartare.mdx
+++ b/src/content/recipes/tuna-tartare.mdx
@@ -4,8 +4,20 @@ aliases:
   - tuna-tartare
 createdAt: 2026-01-03T12:49:00.000Z
 cuisine: mediterranean
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: fresh-tuna-fillet
+        quantity: 300
+        unit: grams
+      - id: extra-virgin-olive-oil
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
+      - id: fine-salt
+        note: to taste
+      - id: lemon-zest
+        quantity: 1
+        note: unwaxed lemon
 serves: 2
 status: evergreen
 title: Tuna tartare
@@ -13,14 +25,6 @@ type: starter
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Fresh tuna fillet (300 g)
-- Extra virgin olive oil (to taste)
-- Black pepper (to taste)
-- Fine salt (to taste)
-- Unwaxed lemon, zest only (1)
-
 ## Steps
 
 1. Take the tuna fillet (previously frozen for safety).

--- a/src/content/recipes/tuna-tataki.mdx
+++ b/src/content/recipes/tuna-tataki.mdx
@@ -4,8 +4,33 @@ aliases:
   - tuna-tataki
 createdAt: 2026-01-03T12:34:00.000Z
 cuisine: asian
-diets:
-  - pescatarian
+ingredient_groups:
+  - ingredients:
+      - id: fresh-tuna-fillet
+        quantity: 300
+        unit: grams
+        note: 'sushi-grade, previously frozen if necessary'
+      - id: soy-sauce
+        quantity: 35
+        unit: milliliters
+      - id: spring-onion
+        quantity: 10
+        unit: grams
+        note: sliced
+      - id: fresh-ginger
+        quantity: 5
+        unit: grams
+        note: sliced
+      - id: rice-vinegar
+        quantity: 5
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: mustard
+        note: to taste
+      - id: toasted-sesame-seeds
+        note: to taste
 serves: 2
 status: evergreen
 title: Tuna tataki
@@ -13,17 +38,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Fresh tuna steak, sushi-grade, previously frozen if necessary (300 g)
-- Soy sauce (35 ml)
-- Spring onion, sliced (10 g)
-- Fresh ginger, sliced (5 g)
-- Rice vinegar (5 ml)
-- Garlic (1 clove)
-- Mustard (to taste)
-- Sesame seeds (to taste)
-
 ## Steps
 
 1. Prepare the marinade by combining the soy sauce, sliced spring onion, garlic clove, sliced fresh ginger, and rice vinegar in a bowl.

--- a/src/content/recipes/two-tone-cauliflower-gnocchi-with-leek-and-potato-soup-and-kale-chips.mdx
+++ b/src/content/recipes/two-tone-cauliflower-gnocchi-with-leek-and-potato-soup-and-kale-chips.mdx
@@ -4,21 +4,20 @@ aliases:
   - two-tone-cauliflower-gnocchi-with-leek-and-potato-soup-and-kale-chips
 createdAt: 2025-12-28T18:58:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - >-
+        note: 'Ingredients for [[two-tone-cauliflower-gnocchi|Two-tone
+        cauliflower gnocchi]]'
+      - 'note: ''Ingredients for [[paprika-kale-chips|Paprika kale chips]]'''
+      - 'note: ''Ingredients for [[leek-and-potato-soup|Leek and potato soup]]'''
 serves: 4
 status: evergreen
 title: Two-tone cauliflower gnocchi with leek and potato soup and kale chips
 type: first-course
-updatedAt: 2026-05-25T05:55:02.000Z
+updatedAt: 2026-06-01T08:51:29.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Ingredients for [[two-tone-cauliflower-gnocchi|Two-tone cauliflower gnocchi]]
-- Ingredients for [[paprika-kale-chips|Paprika kale chips]]
-- Ingredients for [[leek-and-potato-soup|Leek and potato soup]]
-
 ## Steps
 
 1. Make the [[leek-and-potato-soup|Leek and potato soup]].

--- a/src/content/recipes/two-tone-cauliflower-gnocchi.mdx
+++ b/src/content/recipes/two-tone-cauliflower-gnocchi.mdx
@@ -4,8 +4,20 @@ aliases:
   - two-tone-cauliflower-gnocchi
 createdAt: 2025-12-28T18:56:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: cauliflower
+        quantity: 300
+        unit: grams
+      - id: oat-flour
+        quantity: 150
+        unit: grams
+      - id: paprika
+        note: to taste
+      - id: turmeric
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
 serves: 4
 status: evergreen
 title: Two-tone cauliflower gnocchi
@@ -13,14 +25,6 @@ type: first-course
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Cauliflower (300 g)
-- Oat flour (150 g)
-- Paprika (to taste)
-- Turmeric (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. Clean the cauliflower, separate into florets, and steam for 15 minutes.

--- a/src/content/recipes/vegetable-caponata.mdx
+++ b/src/content/recipes/vegetable-caponata.mdx
@@ -4,28 +4,49 @@ aliases:
   - vegetable-caponata
 createdAt: 2025-12-27T19:41:00.000Z
 cuisine: mediterranean
-diets:
-  - vegan
+ingredient_groups:
+  - ingredients:
+      - id: eggplant
+        quantity: 1000
+        unit: grams
+      - id: celery-stalk
+        quantity: 400
+        unit: grams
+      - id: white-onion
+        quantity: 250
+        unit: grams
+      - id: tomato
+        quantity: 200
+        unit: grams
+        note: ripe
+      - id: green-olives
+        quantity: 200
+        unit: grams
+        note: 'in brine, pitted'
+      - id: capers
+        quantity: 50
+        unit: grams
+        note: 'salt-packed, rinsed'
+      - id: pine-nuts
+        quantity: 50
+        unit: grams
+      - id: granulated-sugar
+        quantity: 60
+        unit: grams
+      - id: white-wine-vinegar
+        quantity: 60
+        unit: grams
+      - id: fresh-basil
+        note: as needed
+      - id: tomato-paste
+        quantity: 40
+        unit: grams
 status: budding
 title: Vegetable caponata
 type: side
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Eggplant (1 kg)
-- Celery (400 g)
-- White onions (250 g)
-- Ripe tomatoes (200 g)
-- Green olives in brine (200 g, pitted)
-- Salt-packed capers (50 g, rinsed)
-- Pine nuts (50 g)
-- Sugar (60 g)
-- White wine vinegar (60 g)
-- Basil (as needed)
-- Tomato paste (40 g)
-
 ## Steps
 
 1. Peel and thinly slice the onion.

--- a/src/content/recipes/vegetarian-cabbage-rolls.mdx
+++ b/src/content/recipes/vegetarian-cabbage-rolls.mdx
@@ -4,8 +4,33 @@ aliases:
   - vegetarian-cabbage-rolls
 createdAt: 2025-12-28T19:04:00.000Z
 cuisine: mediterranean
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: savoy-cabbage
+        quantity: 1
+      - id: chickpeas
+        quantity: 460
+        unit: grams
+        note: drained weight
+      - id: carrot
+        quantity: 2
+      - id: red-onion
+        quantity: 1
+      - id: taggiasca-olives
+        quantity: 80
+        unit: grams
+      - id: tahini
+        quantity: 45
+        unit: milliliters
+      - id: garlic
+        quantity: 1
+        unit: clove
+      - id: extra-virgin-olive-oil
+        note: as needed
+      - id: fine-salt
+        note: as needed
+      - id: black-peppercorns
+        note: as needed
 serves: 4
 status: evergreen
 title: Vegetarian cabbage rolls
@@ -13,19 +38,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Large savoy cabbage (1)
-- Cooked chickpeas, drained weight (460 g)
-- Carrots (2)
-- Red onion (1)
-- Taggiasca olives (80 g)
-- Tahini (45 ml)
-- Garlic (1 clove)
-- Extra-virgin olive oil (as needed)
-- Fine salt (as needed)
-- Black pepper (as needed)
-
 ## Steps
 
 1. Remove 8 large, intact cabbage leaves.

--- a/src/content/recipes/venetian-style-whipped-salt-cod.mdx
+++ b/src/content/recipes/venetian-style-whipped-salt-cod.mdx
@@ -4,8 +4,28 @@ aliases:
   - venetian-style-whipped-salt-cod
 createdAt: 2026-05-23T16:57:00.000Z
 cuisine: italian
-diets:
-  - pescatarian
+ingredient_groups:
+  - group: Dish
+    ingredients:
+      - id: stockfish
+        quantity: 800
+        unit: grams
+        note: 'salt cod, already soaked'
+      - id: sunflower-oil
+        quantity: 500
+        unit: grams
+      - id: bay-leaves
+        quantity: 2
+      - id: fine-salt
+        note: to taste
+      - id: black-peppercorns
+        note: to taste
+  - group: Garnish
+    ingredients:
+      - id: parsley
+        note: 'fresh, to taste'
+      - id: black-peppercorns
+        note: to taste
 serves: 4
 status: budding
 title: Venetian-style whipped salt cod
@@ -13,21 +33,6 @@ type: main-course
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-For the dish:
-
-- Stockfish (salt cod), already soaked (800 g)
-- Sunflower seed oil (500 g)
-- Bay leaves (2)
-- Fine salt (to taste)
-- Black pepper (to taste)
-
-For garnish:
-
-- Fresh parsley (to taste)
-- Black pepper (to taste)
-
 ## Steps
 
 1. If using pre-soaked stockfish, rinse it thoroughly several times under cold running water.

--- a/src/content/recipes/wasabi-mayo.mdx
+++ b/src/content/recipes/wasabi-mayo.mdx
@@ -4,8 +4,23 @@ aliases:
   - wasabi-mayo
 createdAt: 2026-01-03T12:52:00.000Z
 cuisine: asian
-diets:
-  - vegetarian
+ingredient_groups:
+  - ingredients:
+      - id: egg-yolk
+        quantity: 2
+      - id: rice-vinegar
+        quantity: 30
+        unit: milliliters
+      - id: sunflower-oil
+        quantity: 100
+        unit: grams
+      - id: salt
+        quantity: 5
+        unit: milliliters
+        note: level
+      - id: wasabi-powder
+        quantity: 5
+        unit: milliliters
 serves: 4
 status: evergreen
 title: Wasabi mayo
@@ -13,14 +28,6 @@ type: sauce
 updatedAt: 2026-05-25T05:55:02.000Z
 contentType: recipes
 ---
-## Ingredients
-
-- Egg yolks (2)
-- Rice vinegar (30 ml)
-- Sunflower seed oil (100 g)
-- Salt (5 ml, level)
-- Wasabi powder (5 ml)
-
 ## Steps
 
 1. Place the egg yolks in the jug of an immersion blender.

--- a/src/data/index.json
+++ b/src/data/index.json
@@ -2487,7 +2487,7 @@
     "type": "recipes",
     "outboundLinks": [
       {
-        "slug": "two-tone-cauliflower-gnocchi",
+        "slug": "leek-and-potato-soup",
         "type": "recipes"
       },
       {
@@ -2495,7 +2495,7 @@
         "type": "recipes"
       },
       {
-        "slug": "leek-and-potato-soup",
+        "slug": "two-tone-cauliflower-gnocchi",
         "type": "recipes"
       }
     ],
@@ -8806,6 +8806,2555 @@
   },
   {
     "ids": [
+      "00 Flour",
+      "00-flour"
+    ],
+    "slug": "00-flour",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "All-Purpose Flour",
+      "all-purpose-flour"
+    ],
+    "slug": "all-purpose-flour",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Anchovy Fillets",
+      "anchovy-fillets"
+    ],
+    "slug": "anchovy-fillets",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Apple Cider Vinegar",
+      "apple-cider-vinegar"
+    ],
+    "slug": "apple-cider-vinegar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Avocado",
+      "avocado"
+    ],
+    "slug": "avocado",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Baking Powder",
+      "baking-powder"
+    ],
+    "slug": "baking-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Balsamic Glaze",
+      "balsamic-glaze"
+    ],
+    "slug": "balsamic-glaze",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Banana Whey Protein",
+      "banana-whey-protein"
+    ],
+    "slug": "banana-whey-protein",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ripe Banana Flesh",
+      "banana"
+    ],
+    "slug": "banana",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Barbecue Sauce",
+      "barbecue-sauce"
+    ],
+    "slug": "barbecue-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Basmati Rice",
+      "basmati-rice"
+    ],
+    "slug": "basmati-rice",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Bay Leaves",
+      "bay-leaves"
+    ],
+    "slug": "bay-leaves",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Beef Chunks",
+      "beef-chuck"
+    ],
+    "slug": "beef-chuck",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Beef Short Rib",
+      "beef-short-rib"
+    ],
+    "slug": "beef-short-rib",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Beef Stock",
+      "beef-stock"
+    ],
+    "slug": "beef-stock",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Beef Tenderloin Steaks",
+      "beef-tenderloin"
+    ],
+    "slug": "beef-tenderloin",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Beef Topside",
+      "beef-topside"
+    ],
+    "slug": "beef-topside",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Black Beans",
+      "black-beans"
+    ],
+    "slug": "black-beans",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Black Peppercorns",
+      "black-peppercorns"
+    ],
+    "slug": "black-peppercorns",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Blackberries",
+      "blackberries"
+    ],
+    "slug": "blackberries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Blueberries",
+      "blueberries"
+    ],
+    "slug": "blueberries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Brandy",
+      "brandy"
+    ],
+    "slug": "brandy",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Breadcrumbs",
+      "breadcrumbs"
+    ],
+    "slug": "breadcrumbs",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Brie",
+      "brie"
+    ],
+    "slug": "brie",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Brown Sugar",
+      "brown-sugar"
+    ],
+    "slug": "brown-sugar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Burrata",
+      "burrata"
+    ],
+    "slug": "burrata",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Butter",
+      "butter"
+    ],
+    "slug": "butter",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Canned Tuna in Oil",
+      "canned-tuna-in-oil"
+    ],
+    "slug": "canned-tuna-in-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Caper Berries",
+      "caper-berries"
+    ],
+    "slug": "caper-berries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Capers",
+      "capers"
+    ],
+    "slug": "capers",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Carnaroli Rice",
+      "carnaroli-rice"
+    ],
+    "slug": "carnaroli-rice",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Carrot",
+      "carrot"
+    ],
+    "slug": "carrot",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cashews",
+      "cashews"
+    ],
+    "slug": "cashews",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Medium Cauliflower",
+      "cauliflower"
+    ],
+    "slug": "cauliflower",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cayenne Pepper",
+      "cayenne-pepper"
+    ],
+    "slug": "cayenne-pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Celery Stalk",
+      "celery-stalk"
+    ],
+    "slug": "celery-stalk",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Champignon Mushrooms",
+      "champignon-mushrooms"
+    ],
+    "slug": "champignon-mushrooms",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cheddar",
+      "cheddar"
+    ],
+    "slug": "cheddar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cherry Tomato",
+      "cherry-tomato"
+    ],
+    "slug": "cherry-tomato",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chicken Breast",
+      "chicken-breast"
+    ],
+    "slug": "chicken-breast",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chicken Thighs",
+      "chicken-thighs"
+    ],
+    "slug": "chicken-thighs",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chicken Wings",
+      "chicken-wings"
+    ],
+    "slug": "chicken-wings",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chicken",
+      "chicken"
+    ],
+    "slug": "chicken",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Canned Chickpeas",
+      "chickpeas"
+    ],
+    "slug": "chickpeas",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chili Flakes",
+      "chili-flakes"
+    ],
+    "slug": "chili-flakes",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chilli Powder",
+      "chilli-powder"
+    ],
+    "slug": "chilli-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chives",
+      "chives"
+    ],
+    "slug": "chives",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Chocolate Chips",
+      "chocolate-chips"
+    ],
+    "slug": "chocolate-chips",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Clarified Butter",
+      "clarified-butter"
+    ],
+    "slug": "clarified-butter",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cloves",
+      "cloves"
+    ],
+    "slug": "cloves",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Unsweetened Cocoa Powder",
+      "cocoa-powder"
+    ],
+    "slug": "cocoa-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Coconut Milk",
+      "coconut-milk"
+    ],
+    "slug": "coconut-milk",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cooked Ham",
+      "cooked-ham"
+    ],
+    "slug": "cooked-ham",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Corn",
+      "corn"
+    ],
+    "slug": "corn",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cornflour",
+      "cornstarch"
+    ],
+    "slug": "cornstarch",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cow Ricotta",
+      "cow-ricotta"
+    ],
+    "slug": "cow-ricotta",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cream Cheese",
+      "cream-cheese"
+    ],
+    "slug": "cream-cheese",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cucumber",
+      "cucumber"
+    ],
+    "slug": "cucumber",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dark Chocolate",
+      "dark-chocolate"
+    ],
+    "slug": "dark-chocolate",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dashi Powder",
+      "dashi-powder"
+    ],
+    "slug": "dashi-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Delica Pumpkin",
+      "delica-pumpkin"
+    ],
+    "slug": "delica-pumpkin",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Digestive Biscuits",
+      "digestive-biscuits"
+    ],
+    "slug": "digestive-biscuits",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dijon Mustard",
+      "dijon-mustard"
+    ],
+    "slug": "dijon-mustard",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dried Chili Pepper",
+      "dried-chili-pepper"
+    ],
+    "slug": "dried-chili-pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dried Rice Vermicelli",
+      "dried-rice-vermicelli"
+    ],
+    "slug": "dried-rice-vermicelli",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dried Wakame",
+      "dried-wakame"
+    ],
+    "slug": "dried-wakame",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Dry White Wine",
+      "dry-white-wine"
+    ],
+    "slug": "dry-white-wine",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Remilled Durum Wheat Semolina",
+      "durum-wheat-semolina"
+    ],
+    "slug": "durum-wheat-semolina",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Egg Yolk",
+      "egg-yolk"
+    ],
+    "slug": "egg-yolk",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Eggs",
+      "egg"
+    ],
+    "slug": "egg",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Eggplant",
+      "eggplant"
+    ],
+    "slug": "eggplant",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Extra Virgin Olive Oil",
+      "extra-virgin-olive-oil"
+    ],
+    "slug": "extra-virgin-olive-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fine Salt",
+      "fine-salt"
+    ],
+    "slug": "fine-salt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fior di Latte Mozzarella",
+      "fior-di-latte-mozzarella"
+    ],
+    "slug": "fior-di-latte-mozzarella",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Firm Tofu",
+      "firm-tofu"
+    ],
+    "slug": "firm-tofu",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Baker’s Yeast",
+      "Fresh Baker's Yeast",
+      "fresh-bakers-yeast"
+    ],
+    "slug": "fresh-bakers-yeast",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Basil Leaves",
+      "fresh-basil"
+    ],
+    "slug": "fresh-basil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Chili",
+      "fresh-chili"
+    ],
+    "slug": "fresh-chili",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Cilantro",
+      "fresh-coriander",
+      "fresh-cilantro"
+    ],
+    "slug": "fresh-cilantro",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Cilantro",
+      "fresh-coriander"
+    ],
+    "slug": "fresh-coriander",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Ginger",
+      "fresh-ginger"
+    ],
+    "slug": "fresh-ginger",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Liquid Cream",
+      "fresh-liquid-cream"
+    ],
+    "slug": "fresh-liquid-cream",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Mint",
+      "fresh-mint"
+    ],
+    "slug": "fresh-mint",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Tuna Fillet",
+      "fresh-tuna-fillet"
+    ],
+    "slug": "fresh-tuna-fillet",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Gaeta Olives",
+      "gaeta-olives"
+    ],
+    "slug": "gaeta-olives",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Garlic or Ginger Paste",
+      "garlic-ginger-paste"
+    ],
+    "slug": "garlic-ginger-paste",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Garlic Powder",
+      "garlic-powder"
+    ],
+    "slug": "garlic-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Garlic Clove",
+      "garlic"
+    ],
+    "slug": "garlic",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Genovese Pesto",
+      "genovese-pesto"
+    ],
+    "slug": "genovese-pesto",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Gilthead Bream Fillet",
+      "gilthead-bream-fillet"
+    ],
+    "slug": "gilthead-bream-fillet",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Golden Apples",
+      "golden-apple"
+    ],
+    "slug": "golden-apple",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Golden Onion",
+      "golden-onion"
+    ],
+    "slug": "golden-onion",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Gorgonzola",
+      "gorgonzola"
+    ],
+    "slug": "gorgonzola",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Grana Padano DOP",
+      "grana-padano"
+    ],
+    "slug": "grana-padano",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Granulated Sugar",
+      "granulated-sugar"
+    ],
+    "slug": "granulated-sugar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Greek Yogurt",
+      "greek-yogurt"
+    ],
+    "slug": "greek-yogurt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Green Olives",
+      "green-olives"
+    ],
+    "slug": "green-olives",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Green Peppercorns in Brine",
+      "green-peppercorns-brine"
+    ],
+    "slug": "green-peppercorns-brine",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Beef",
+      "ground-beef"
+    ],
+    "slug": "ground-beef",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Cinnamon",
+      "ground-cinnamon"
+    ],
+    "slug": "ground-cinnamon",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Coriander",
+      "ground-coriander"
+    ],
+    "slug": "ground-coriander",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Cumin",
+      "ground-cumin"
+    ],
+    "slug": "ground-cumin",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Garam Masala",
+      "ground-garam-masala"
+    ],
+    "slug": "ground-garam-masala",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Pork",
+      "ground-pork"
+    ],
+    "slug": "ground-pork",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ground Turmeric",
+      "ground-turmeric"
+    ],
+    "slug": "ground-turmeric",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Guanciale",
+      "guanciale"
+    ],
+    "slug": "guanciale",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Hamburger Bun",
+      "hamburger-bun"
+    ],
+    "slug": "hamburger-bun",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Hazelnuts",
+      "hazelnuts"
+    ],
+    "slug": "hazelnuts",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Heavy Cream",
+      "heavy-cream"
+    ],
+    "slug": "heavy-cream",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Honey",
+      "honey"
+    ],
+    "slug": "honey",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Hot Paprika",
+      "hot-paprika"
+    ],
+    "slug": "hot-paprika",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ice Cubes",
+      "ice-cubes"
+    ],
+    "slug": "ice-cubes",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ketchup",
+      "ketchup"
+    ],
+    "slug": "ketchup",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "King Prawns",
+      "king-prawns"
+    ],
+    "slug": "king-prawns",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lamb’s Lettuce",
+      "Lamb's Lettuce",
+      "lambs-lettuce"
+    ],
+    "slug": "lambs-lettuce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lean Beef",
+      "lean-beef"
+    ],
+    "slug": "lean-beef",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Leek",
+      "leek"
+    ],
+    "slug": "leek",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lemon Juice",
+      "lemon-juice"
+    ],
+    "slug": "lemon-juice",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lemon Thyme",
+      "lemon-thyme"
+    ],
+    "slug": "lemon-thyme",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lemon Zest",
+      "lemon-zest"
+    ],
+    "slug": "lemon-zest",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lemon",
+      "lemon"
+    ],
+    "slug": "lemon",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Cooked Lentils",
+      "lentils"
+    ],
+    "slug": "lentils",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lettuce",
+      "lettuce"
+    ],
+    "slug": "lettuce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Light Soy Sauce",
+      "light-soy-sauce"
+    ],
+    "slug": "light-soy-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lime Juice",
+      "lime-juice"
+    ],
+    "slug": "lime-juice",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Lime Zest",
+      "lime-zest"
+    ],
+    "slug": "lime-zest",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Low-Fat Yogurt",
+      "low-fat-yogurt"
+    ],
+    "slug": "low-fat-yogurt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Maple Syrup",
+      "maple-syrup"
+    ],
+    "slug": "maple-syrup",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mayonnaise",
+      "mayonnaise"
+    ],
+    "slug": "mayonnaise",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Meat Broth",
+      "meat-broth"
+    ],
+    "slug": "meat-broth",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mild Curry Powder",
+      "mild-curry-powder"
+    ],
+    "slug": "mild-curry-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Milk",
+      "milk"
+    ],
+    "slug": "milk",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mirin",
+      "mirin"
+    ],
+    "slug": "mirin",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mixed Berries",
+      "mixed-berries"
+    ],
+    "slug": "mixed-berries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mixed Salad Greens",
+      "mixed-salad-greens"
+    ],
+    "slug": "mixed-salad-greens",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mortadella",
+      "mortadella"
+    ],
+    "slug": "mortadella",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mullet Bottarga",
+      "mullet-bottarga"
+    ],
+    "slug": "mullet-bottarga",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mussels",
+      "mussels"
+    ],
+    "slug": "mussels",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Mustard",
+      "mustard"
+    ],
+    "slug": "mustard",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "‘Nduja",
+      "''Nduja",
+      "nduja"
+    ],
+    "slug": "nduja",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ripe Nectarines",
+      "nectarine"
+    ],
+    "slug": "nectarine",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Nutella",
+      "nutella"
+    ],
+    "slug": "nutella",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Nutmeg",
+      "nutmeg"
+    ],
+    "slug": "nutmeg",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Oat Flour",
+      "oat-flour"
+    ],
+    "slug": "oat-flour",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Olive Oil",
+      "olive-oil"
+    ],
+    "slug": "olive-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Medium Onion",
+      "onion"
+    ],
+    "slug": "onion",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Orange Juice",
+      "orange-juice"
+    ],
+    "slug": "orange-juice",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Oregano",
+      "oregano"
+    ],
+    "slug": "oregano",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Ossobuco",
+      "ossobuco"
+    ],
+    "slug": "ossobuco",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Oyster Mushrooms",
+      "oyster-mushrooms"
+    ],
+    "slug": "oyster-mushrooms",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Oyster Sauce",
+      "oyster-sauce"
+    ],
+    "slug": "oyster-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Pancetta",
+      "pancetta"
+    ],
+    "slug": "pancetta",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Panko",
+      "panko"
+    ],
+    "slug": "panko",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Paprika",
+      "paprika"
+    ],
+    "slug": "paprika",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Parmigiano Reggiano DOP",
+      "parmigiano-reggiano"
+    ],
+    "slug": "parmigiano-reggiano",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Parsley",
+      "parsley"
+    ],
+    "slug": "parsley",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pasta",
+      "pasta"
+    ],
+    "slug": "pasta",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Peanut Butter",
+      "peanut-butter"
+    ],
+    "slug": "peanut-butter",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Peanut Oil",
+      "peanut-oil"
+    ],
+    "slug": "peanut-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pear",
+      "pear"
+    ],
+    "slug": "pear",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pearled Farro",
+      "pearled-farro"
+    ],
+    "slug": "pearled-farro",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Peas",
+      "peas"
+    ],
+    "slug": "peas",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pecorino Romano",
+      "pecorino-romano"
+    ],
+    "slug": "pecorino-romano",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sardinian Pecorino",
+      "pecorino-sardo"
+    ],
+    "slug": "pecorino-sardo",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Peeled Tomatoes",
+      "peeled-tomatoes"
+    ],
+    "slug": "peeled-tomatoes",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pepper",
+      "pepper"
+    ],
+    "slug": "pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pine Nuts",
+      "pine-nuts"
+    ],
+    "slug": "pine-nuts",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pinsa Romana Base",
+      "pinsa-romana-base"
+    ],
+    "slug": "pinsa-romana-base",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pistachio",
+      "pistachio"
+    ],
+    "slug": "pistachio",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Plain Yogurt",
+      "plain-yogurt"
+    ],
+    "slug": "plain-yogurt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pork Loin Chops",
+      "pork-loin-chops"
+    ],
+    "slug": "pork-loin-chops",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pork Ribs",
+      "pork-ribs"
+    ],
+    "slug": "pork-ribs",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Potato Starch",
+      "potato-starch"
+    ],
+    "slug": "potato-starch",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Medium-Large Potatoes",
+      "potato"
+    ],
+    "slug": "potato",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Powdered Sugar",
+      "powdered-sugar"
+    ],
+    "slug": "powdered-sugar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Provolone del Monaco",
+      "provolone-del-monaco"
+    ],
+    "slug": "provolone-del-monaco",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Round Puff Pastry Sheet",
+      "puff-pastry-sheet"
+    ],
+    "slug": "puff-pastry-sheet",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Radicchio",
+      "radicchio"
+    ],
+    "slug": "radicchio",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Raspberries",
+      "raspberries"
+    ],
+    "slug": "raspberries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Rayu Chili Oil",
+      "rayu-chili-oil"
+    ],
+    "slug": "rayu-chili-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Red Bell Pepper",
+      "red-bell-pepper"
+    ],
+    "slug": "red-bell-pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Red Cabbage",
+      "red-cabbage"
+    ],
+    "slug": "red-cabbage",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Red Miso Paste",
+      "red-miso-paste"
+    ],
+    "slug": "red-miso-paste",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Red Onion",
+      "red-onion"
+    ],
+    "slug": "red-onion",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Red Wine",
+      "red-wine"
+    ],
+    "slug": "red-wine",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Redcurrants",
+      "redcurrants"
+    ],
+    "slug": "redcurrants",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Rice Vinegar",
+      "rice-vinegar"
+    ],
+    "slug": "rice-vinegar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Rolled Oats",
+      "rolled-oats"
+    ],
+    "slug": "rolled-oats",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Rosemary",
+      "rosemary"
+    ],
+    "slug": "rosemary",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Saffron",
+      "saffron"
+    ],
+    "slug": "saffron",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sage Leaves",
+      "sage"
+    ],
+    "slug": "sage",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sake",
+      "sake"
+    ],
+    "slug": "sake",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Skinless Salmon Fillet",
+      "salmon-fillet"
+    ],
+    "slug": "salmon-fillet",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Salt",
+      "salt"
+    ],
+    "slug": "salt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": [
+      {
+        "slug": "salt-fat-acid-heat",
+        "type": "books"
+      }
+    ]
+  },
+  {
+    "ids": [
+      "Sausage",
+      "sausage"
+    ],
+    "slug": "sausage",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Savoy Cabbage",
+      "savoy-cabbage"
+    ],
+    "slug": "savoy-cabbage",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Coarse Sea Salt",
+      "sea-salt"
+    ],
+    "slug": "sea-salt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Seitan",
+      "seitan"
+    ],
+    "slug": "seitan",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sesame Oil",
+      "sesame-oil"
+    ],
+    "slug": "sesame-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sesame or Poppy Seeds",
+      "sesame-or-poppy-seeds"
+    ],
+    "slug": "sesame-or-poppy-seeds",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Shallot",
+      "shallot"
+    ],
+    "slug": "shallot",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sheet Gelatin",
+      "sheet-gelatin"
+    ],
+    "slug": "sheet-gelatin",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Shrimp Head",
+      "shrimp-head"
+    ],
+    "slug": "shrimp-head",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Smoked Paprika",
+      "smoked-paprika"
+    ],
+    "slug": "smoked-paprika",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Smoked Salmon",
+      "smoked-salmon"
+    ],
+    "slug": "smoked-salmon",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Soffritto Mix",
+      "soffritto-mix"
+    ],
+    "slug": "soffritto-mix",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Soy Sauce",
+      "soy-sauce"
+    ],
+    "slug": "soy-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Soy Yogurt",
+      "soy-yogurt"
+    ],
+    "slug": "soy-yogurt",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Spaghetti",
+      "spaghetti"
+    ],
+    "slug": "spaghetti",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Spaghettoni",
+      "spaghettoni"
+    ],
+    "slug": "spaghettoni",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Speck Alto Adige IGP",
+      "speck"
+    ],
+    "slug": "speck",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Spinach",
+      "spinach"
+    ],
+    "slug": "spinach",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Spring Onion",
+      "spring-onion"
+    ],
+    "slug": "spring-onion",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Squid",
+      "squid"
+    ],
+    "slug": "squid",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Stockfish",
+      "stockfish"
+    ],
+    "slug": "stockfish",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Fresh Strawberries",
+      "strawberries"
+    ],
+    "slug": "strawberries",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sun-Dried Tomatoes",
+      "sun-dried-tomatoes"
+    ],
+    "slug": "sun-dried-tomatoes",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sunflower Oil",
+      "sunflower-oil"
+    ],
+    "slug": "sunflower-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sweet Paprika",
+      "sweet-paprika"
+    ],
+    "slug": "sweet-paprika",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Sweet Provola",
+      "sweet-provola"
+    ],
+    "slug": "sweet-provola",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Pitted Taggiasca Olives",
+      "taggiasca-olives"
+    ],
+    "slug": "taggiasca-olives",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tahini",
+      "tahini"
+    ],
+    "slug": "tahini",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Taleggio DOP",
+      "taleggio"
+    ],
+    "slug": "taleggio",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Thyme",
+      "thyme"
+    ],
+    "slug": "thyme",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Toasted Sesame Oil",
+      "toasted-sesame-oil"
+    ],
+    "slug": "toasted-sesame-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Toasted Sesame Seeds",
+      "toasted-sesame-seeds"
+    ],
+    "slug": "toasted-sesame-seeds",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tomato Passata",
+      "tomato-passata"
+    ],
+    "slug": "tomato-passata",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Double Concentrated Tomato Paste",
+      "tomato-paste"
+    ],
+    "slug": "tomato-paste",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tomatoes",
+      "tomato"
+    ],
+    "slug": "tomato",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tonkatsu Sauce",
+      "tonkatsu-sauce"
+    ],
+    "slug": "tonkatsu-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tortillas",
+      "tortillas"
+    ],
+    "slug": "tortillas",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Turmeric",
+      "turmeric"
+    ],
+    "slug": "turmeric",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Tuscan Kale Leaves",
+      "tuscan-kale"
+    ],
+    "slug": "tuscan-kale",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vanilla Extract",
+      "vanilla-extract"
+    ],
+    "slug": "vanilla-extract",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Veal Bones",
+      "veal-bones"
+    ],
+    "slug": "veal-bones",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Veal Escalopes",
+      "veal-escalopes"
+    ],
+    "slug": "veal-escalopes",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vegan Grated Cheese",
+      "vegan-grated-cheese"
+    ],
+    "slug": "vegan-grated-cheese",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vegan Ricotta",
+      "vegan-ricotta"
+    ],
+    "slug": "vegan-ricotta",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vegetable Oil",
+      "vegetable-oil"
+    ],
+    "slug": "vegetable-oil",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vegetable Stock",
+      "vegetable-stock"
+    ],
+    "slug": "vegetable-stock",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Vegetarian Oyster Sauce",
+      "vegetarian-oyster-sauce"
+    ],
+    "slug": "vegetarian-oyster-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Walnuts",
+      "walnuts"
+    ],
+    "slug": "walnuts",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Wasabi Powder",
+      "wasabi-powder"
+    ],
+    "slug": "wasabi-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Water",
+      "water"
+    ],
+    "slug": "water",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "White Cabbage",
+      "white-cabbage"
+    ],
+    "slug": "white-cabbage",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "White Onion",
+      "white-onion"
+    ],
+    "slug": "white-onion",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "White Pepper",
+      "white-pepper"
+    ],
+    "slug": "white-pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "White Peppercorns",
+      "white-peppercorns"
+    ],
+    "slug": "white-peppercorns",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "White Wine Vinegar",
+      "white-wine-vinegar"
+    ],
+    "slug": "white-wine-vinegar",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Whole Wheat Bread",
+      "whole-wheat-bread"
+    ],
+    "slug": "whole-wheat-bread",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Worcestershire Sauce",
+      "worcestershire-sauce"
+    ],
+    "slug": "worcestershire-sauce",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Yellow Bell Pepper",
+      "yellow-bell-pepper"
+    ],
+    "slug": "yellow-bell-pepper",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Yellow Mustard Powder",
+      "yellow-mustard-powder"
+    ],
+    "slug": "yellow-mustard-powder",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
+      "Zucchini",
+      "zucchini"
+    ],
+    "slug": "zucchini",
+    "type": "ingredients",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
       "100 Truths You Will Learn Too Late",
       "100-truths-you-will-learn-too-late"
     ],
@@ -9968,7 +12517,12 @@
     ],
     "slug": "salt-fat-acid-heat",
     "type": "books",
-    "outboundLinks": [],
+    "outboundLinks": [
+      {
+        "slug": "salt",
+        "type": "ingredients"
+      }
+    ],
     "inboundLinks": []
   },
   {

--- a/src/lib/filters/diet.ts
+++ b/src/lib/filters/diet.ts
@@ -1,5 +1,6 @@
 import type { ZendoCollectionEntry } from "../zendo/content";
 import type { FilterConfig } from "../zendo/config";
+import { deriveDiets, getIngredientDietMap, getRecipeIngredientGroupsMap } from "../recipes/diets";
 
 export default async function dietFilter(): Promise<FilterConfig> {
   return {
@@ -20,10 +21,12 @@ export default async function dietFilter(): Promise<FilterConfig> {
         return entries;
       }
 
+      const [dietMap, recipeMap] = await Promise.all([getIngredientDietMap(), getRecipeIngredientGroupsMap()]);
+
       return entries.filter((entry) => {
-        if (entry.collection === "recipes" && "diets" in entry.data) {
-          const entryDiets = (entry.data.diets ?? []) as string[];
-          return entryDiets.length > 0 && entryDiets.some((diet: string) => selectedValues.includes(diet));
+        if (entry.collection === "recipes" && "ingredient_groups" in entry.data) {
+          const entryDiets = deriveDiets(entry.data.ingredient_groups, dietMap, recipeMap);
+          return entryDiets.length > 0 && entryDiets.some((diet) => selectedValues.includes(diet));
         }
 
         return true;

--- a/src/lib/recipes/diets.ts
+++ b/src/lib/recipes/diets.ts
@@ -1,0 +1,111 @@
+import type { CollectionEntry } from "astro:content";
+
+export const DIETS = ["omnivore", "vegetarian", "vegan", "pescatarian"] as const;
+
+export type Diet = (typeof DIETS)[number];
+
+export type IngredientGroup = CollectionEntry<"recipes">["data"]["ingredient_groups"][number];
+
+/**
+ * Builds a lookup of ingredient id → the diets that ingredient is compatible
+ * with, sourced from the `ingredients` glossary collection.
+ */
+export async function getIngredientDietMap(): Promise<Map<string, Diet[]>> {
+  // Imported lazily so this module can be loaded outside the Astro runtime
+  // (e.g. by the zendo CLI, which evaluates garden.config and its filters).
+  const { getCollection } = await import("astro:content");
+  const ingredients = await getCollection("ingredients");
+
+  return new Map(ingredients.map((ingredient) => [ingredient.id, ingredient.data.diets as Diet[]]));
+}
+
+/**
+ * Builds a lookup of recipe id → its ingredient groups, used to resolve
+ * cross-references (e.g. "Ingredients for [[bbq-sauce|BBQ Sauce]]").
+ */
+export async function getRecipeIngredientGroupsMap(): Promise<Map<string, IngredientGroup[]>> {
+  const { getCollection } = await import("astro:content");
+  const recipes = await getCollection("recipes");
+
+  return new Map(recipes.map((recipe) => [recipe.id, recipe.data.ingredient_groups]));
+}
+
+/**
+ * Collects every ingredient id used by a recipe, following note-only
+ * cross-references to other recipes (e.g. "Ingredients for [[bbq-sauce]]") so
+ * the borrowed ingredients are counted too. Cycles are guarded via `seen`.
+ */
+function collectIngredientIds(
+  ingredientGroups: IngredientGroup[],
+  recipeMap: Map<string, IngredientGroup[]>,
+  seen: Set<string>,
+  ids: Set<string>
+): void {
+  for (const group of ingredientGroups) {
+    for (const ingredient of group.ingredients) {
+      if (ingredient.id) {
+        ids.add(ingredient.id);
+        continue;
+      }
+
+      // Note-only entry: if it references another recipe, fold in its ingredients.
+      const match = ingredient.note?.match(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/);
+      const slug = match?.[1]?.trim();
+
+      if (slug && !seen.has(slug)) {
+        seen.add(slug);
+        const referenced = recipeMap.get(slug);
+        if (referenced) {
+          collectIngredientIds(referenced, recipeMap, seen, ids);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Derives a recipe's diets as the intersection of its ingredients' diets:
+ * a recipe is compatible with a diet only if every (known) ingredient is.
+ * Ingredients missing from the glossary impose no constraint, and a recipe
+ * with no known ingredients yields no diets. When `recipeMap` is provided,
+ * cross-referenced recipes' ingredients are included in the derivation.
+ */
+export function deriveDiets(
+  ingredientGroups: IngredientGroup[],
+  dietMap: Map<string, Diet[]>,
+  recipeMap: Map<string, IngredientGroup[]> = new Map()
+): Diet[] {
+  const ids = new Set<string>();
+  collectIngredientIds(ingredientGroups, recipeMap, new Set(), ids);
+
+  let allowed: Set<Diet> | null = null;
+
+  for (const id of ids) {
+    const diets = dietMap.get(id);
+
+    if (!diets) {
+      continue;
+    }
+
+    if (allowed === null) {
+      allowed = new Set(diets);
+    } else {
+      allowed = new Set(diets.filter((diet) => allowed!.has(diet)));
+    }
+  }
+
+  if (allowed === null) {
+    return [];
+  }
+
+  return DIETS.filter((diet) => allowed!.has(diet));
+}
+
+/**
+ * Convenience wrapper that loads the glossary and recipe map and derives a
+ * single recipe's diets.
+ */
+export async function getRecipeDiets(recipe: CollectionEntry<"recipes">): Promise<Diet[]> {
+  const [dietMap, recipeMap] = await Promise.all([getIngredientDietMap(), getRecipeIngredientGroupsMap()]);
+  return deriveDiets(recipe.data.ingredient_groups, dietMap, recipeMap);
+}

--- a/src/lib/recipes/ingredients.ts
+++ b/src/lib/recipes/ingredients.ts
@@ -1,0 +1,74 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+type IngredientItem = CollectionEntry<"recipes">["data"]["ingredient_groups"][number]["ingredients"][number];
+
+// Units rendered as abbreviations and never pluralized.
+const UNIT_ABBREVIATIONS: Record<string, string> = {
+  grams: "g",
+  milliliters: "ml",
+};
+
+/**
+ * Builds a lookup of ingredient id → display name from the glossary, falling
+ * back to a prettified id for anything not (yet) in the glossary.
+ */
+export async function getIngredientNameMap(): Promise<Map<string, string>> {
+  const ingredients = await getCollection("ingredients");
+  return new Map(ingredients.map((ingredient) => [ingredient.id, ingredient.data.title]));
+}
+
+export function prettifyId(id: string): string {
+  return id
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function pluralize(word: string): string {
+  if (word.endsWith("s")) {
+    return word; // assume already plural (e.g. "sprigs", "leaves", "fillets")
+  }
+  if (/(x|z|ch|sh)$/.test(word)) {
+    return `${word}es`; // pinch → pinches, glass handled below, bunch → bunches
+  }
+  if (word.endsWith("ss")) {
+    return `${word}es`; // glass → glasses
+  }
+  return `${word}s`;
+}
+
+/**
+ * Renders a unit for display: abbreviations stay singular, "count" is dropped,
+ * everything else is pluralized when the quantity isn't exactly 1.
+ */
+export function formatUnit(unit: string, quantity?: number): string {
+  const abbreviation = UNIT_ABBREVIATIONS[unit];
+  if (abbreviation) {
+    return abbreviation;
+  }
+
+  if (unit === "count") {
+    return "";
+  }
+
+  return quantity !== undefined && quantity !== 1 ? pluralize(unit) : unit;
+}
+
+/**
+ * Formats a single ingredient as `Name (quantity unit, note)`, omitting any
+ * empty parts. Matches the format the recipe pages used before the migration.
+ */
+export function formatIngredientLine(item: IngredientItem, name: string): string {
+  const parts: string[] = [];
+
+  if (item.quantity !== undefined) {
+    const unit = item.unit ? formatUnit(item.unit, item.quantity) : "";
+    parts.push(unit ? `${item.quantity} ${unit}` : `${item.quantity}`);
+  }
+
+  if (item.note) {
+    parts.push(item.note);
+  }
+
+  return parts.length > 0 ? `${name} (${parts.join(", ")})` : name;
+}

--- a/src/pages/recipes/[id].astro
+++ b/src/pages/recipes/[id].astro
@@ -8,6 +8,7 @@ import RecipeIllustration from "@components/content/recipes/RecipeIllustration.a
 import ContentSidebar from "@components/content/ContentSidebar.astro";
 import ContentDetail from "@components/content/ContentDetail.astro";
 import RecipeMeta from "@components/content/recipes/RecipeMeta.astro";
+import IngredientList from "@components/content/recipes/IngredientList.astro";
 
 export async function getStaticPaths() {
   const recipes = await getCollection("recipes");
@@ -30,6 +31,8 @@ const { recipe } = Astro.props;
     </ArrowLink>
 
     <RecipeMeta content={recipe} slot="meta" />
+
+    <IngredientList recipe={recipe} slot="pre-content" />
 
     <ContentSidebar entry={recipe} slot="sidebar">
       <RecipeIllustration recipe={recipe} class="w-full max-w-[250px] lg:max-w-full h-auto rounded mt-4 lg:mt-0" />


### PR DESCRIPTION
## Context

The `digital-garden` vault (source of truth, pulled at build time) restructured its recipe data:

| Old (what the site read) | New |
| --- | --- |
| `diets:` in recipe frontmatter | **removed** — diets now live per-ingredient in a new `ingredients/` glossary |
| ingredients hand-written in `## Ingredients` body | structured `ingredient_groups:` frontmatter (`id`/`quantity`/`unit`/`note`) |
| body = Ingredients + Steps + Notes | body = Steps + optional Notes |

The next content sync would otherwise break the build. This PR updates the schema and rendering to read the new shape **while keeping the recipe pages visually the same**, and re-syncs `src/content`.

## Changes

- **Schema** (`src/content.config.ts`): new `ingredients` collection; recipe schema drops `diets`, gains `ingredient_groups` (tolerant of note-only cross-reference entries like `Ingredients for [[bbq-sauce|BBQ Sauce]]`).
- **Sync** (`garden.config.ts`): syncs the `ingredients/` glossary (no search; stays out of `collectionIds`).
- **Diets** (`src/lib/recipes/diets.ts`): derived as the **intersection** of a recipe's ingredients' diets, **following cross-references** to other recipes so borrowed ingredients are counted (cycle-guarded). Used by `RecipeMeta` and the index-page diet filter.
- **Ingredients** (`src/lib/recipes/ingredients.ts` + `IngredientList.astro`): rendered as `Name (qty unit, note)` with group labels and wikilink cross-references, via a new `pre-content` slot on `ContentDetail`. The "Ingredients" heading is re-added to the recipe TOC.
- Re-synced `src/content` (recipes + new ingredients glossary) and `src/data/index.json`.

## Verification

- `npm run build` (`astro check`) passes — 0 errors.
- Tested in Chrome on the dev server: recipe detail pages (ingredients/steps/notes order, derived diets, illustration, TOC), grouped recipes ("For the batter:" / "For the pan:"), cross-reference links, and the index-page diet filter (e.g. cacio e pepe with pears correctly excluded from Vegan once its referenced pecorino is counted).

## Notes

- Ingredient wording and diet tags are reconstructed from the structured data, so they are **not byte-identical** to the old hand-authored text (e.g. a recipe may now show more diet tags via the intersection rule).
- Pre-existing, unrelated eslint error in `src/lib/zendo/sources/notion.ts` (unused `fileUrl`) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)